### PR TITLE
Migration utility + dict-based config persistence (fixes #34)

### DIFF
--- a/src/Ronin.jl
+++ b/src/Ronin.jl
@@ -33,8 +33,51 @@ module Ronin
     export run_evaluation, sweep_pass2_met_probs, run_hypertuning, compute_auc_roc
     export load_model_with_metadata, inspect_model_configuration
     export compute_importance, generate_pass_masks, met_prob_histogram
+    export migrate_model_config 
 
 
+
+    """
+        migrate_model_config(infile::String, outfile::String; key=nothing)
+
+        Function to migrate an old model configuration file to the new ModelConfig struct format. 
+        Reads the old configuration object in, maps any overlapping fields to the new ModelConfig struct, 
+        and saves the new struct to a new JLD2 file.
+    """
+    function migrate_model_config(infile::String, outfile::String; key=nothing)
+
+        actual_key = jldopen(infile, "r") do f
+            ks = collect(keys(f))
+            println("Keys found: ", ks)
+
+            if key !== nothing
+                String(key)
+            elseif length(ks) == 1
+                String(ks[1])
+            else
+                error("Multiple keys found. Pass key=\"...\" explicitly.")
+            end
+        end
+
+        old = JLD2.load(infile, actual_key)
+
+        kwargs = Dict{Symbol,Any}()
+
+        for fld in fieldnames(ModelConfig)
+            if hasproperty(old, fld)
+                kwargs[fld] = getproperty(old, fld)
+            end
+        end
+
+        new = ModelConfig(; kwargs...)
+
+        jldsave(outfile; model_config = new)
+
+        println("Migrated ModelConfig saved to: $outfile")
+        return new
+    end
+        
+            
 
     """
         load_model(path::String, task_mode::String)

--- a/src/Ronin.jl
+++ b/src/Ronin.jl
@@ -33,51 +33,7 @@ module Ronin
     export run_evaluation, sweep_pass2_met_probs, run_hypertuning, compute_auc_roc
     export load_model_with_metadata, inspect_model_configuration
     export compute_importance, generate_pass_masks, met_prob_histogram
-    export migrate_model_config 
-
-
-
-    """
-        migrate_model_config(infile::String, outfile::String; key=nothing)
-
-        Function to migrate an old model configuration file to the new ModelConfig struct format. 
-        Reads the old configuration object in, maps any overlapping fields to the new ModelConfig struct, 
-        and saves the new struct to a new JLD2 file.
-    """
-    function migrate_model_config(infile::String, outfile::String; key=nothing)
-
-        actual_key = jldopen(infile, "r") do f
-            ks = collect(keys(f))
-            println("Keys found: ", ks)
-
-            if key !== nothing
-                String(key)
-            elseif length(ks) == 1
-                String(ks[1])
-            else
-                error("Multiple keys found. Pass key=\"...\" explicitly.")
-            end
-        end
-
-        old = JLD2.load(infile, actual_key)
-
-        kwargs = Dict{Symbol,Any}()
-
-        for fld in fieldnames(ModelConfig)
-            if hasproperty(old, fld)
-                kwargs[fld] = getproperty(old, fld)
-            end
-        end
-
-        new = ModelConfig(; kwargs...)
-
-        jldsave(outfile; model_config = new)
-
-        println("Migrated ModelConfig saved to: $outfile")
-        return new
-    end
-        
-            
+    export save_config, load_config, migrate_model_config
 
     """
         load_model(path::String, task_mode::String)
@@ -591,6 +547,157 @@ module Ronin
         end
 
         ModelConfig(; num_models=num_models, input_path=input_path, merged...)
+    end
+
+    ## Required ModelConfig fields (no @kwdef defaults). Used by load_config to
+    ## validate that legacy single_stored_object files actually yielded enough
+    ## values to construct a ModelConfig.
+    const _MODELCONFIG_REQUIRED_FIELDS = (:num_models, :model_output_paths, :met_probs,
+                                          :feature_output_paths, :input_path, :task_mode,
+                                          :file_preprocessed)
+
+    """
+        save_config(path::String, config::ModelConfig)
+
+    Save a `ModelConfig` to a JLD2 file in dict-keyed format: one key per field.
+
+    This format is robust to struct evolution. Adding a field to `ModelConfig` later
+    just means a new key for fresh files; old files still load via `load_config`,
+    which fills any missing key with the struct's default. No migration required
+    on every shape change.
+
+    Replaces the legacy pattern `JLD2.save_object(path, config)`, which pickled the
+    struct shape and broke on every field addition (see issue #34). The legacy
+    format is still readable by `load_config`.
+    """
+    function save_config(path::String, config::ModelConfig)
+        ## Symbol-keyed Dict so the `;pairs...` splat lands as JLD2 keyword args.
+        ## JLD2 serializes keyword names as string keys on disk, which `load_config`
+        ## then reads back via `data["field_name"]`.
+        pairs = Dict{Symbol,Any}()
+        for fld in fieldnames(ModelConfig)
+            pairs[fld] = getproperty(config, fld)
+        end
+        ## Format marker so future loaders can detect / version this layout.
+        pairs[:__ronin_config_format__] = "dict_v1"
+        jldsave(path; pairs...)
+        return path
+    end
+
+    """
+        load_config(path::String) -> ModelConfig
+
+    Load a `ModelConfig` from a JLD2 file, transparently handling both storage formats:
+
+    - **Dict-keyed format** (written by `save_config`): each ModelConfig field is
+      stored under its own key. Missing keys fall back to the struct's `@kwdef`
+      defaults, so future field additions do not break old files.
+
+    - **Legacy `save_object` format** (single `single_stored_object` key holding a
+      pickled struct): JLD2 may load these as a `ReconstructedMutable` shadow type
+      when the saved struct shape no longer matches the current `ModelConfig`.
+      Each accessible field is copied via `getproperty` into a fresh, real
+      `ModelConfig` instance; defaults fill in any new fields the saved file lacks.
+
+    A real, mutable `ModelConfig` is returned regardless of source format —
+    callers can then assign to fields (`config.task_paths = [...]`) without
+    hitting `setproperty!` errors on `ReconstructedMutable`.
+    """
+    function load_config(path::String)
+        isfile(path) || error("Config file not found: $(path)")
+        data = JLD2.load(path)
+        data isa Dict || error("Unexpected JLD2 contents in $(path): $(typeof(data))")
+
+        ## Legacy save_object: one key, "single_stored_object", holding a pickled struct.
+        if haskey(data, "single_stored_object")
+            return _load_legacy_config(data["single_stored_object"], path)
+        end
+
+        ## Dict-keyed format. Match keys against current ModelConfig fields and fill
+        ## defaults for anything missing.
+        field_names = fieldnames(ModelConfig)
+        matched = count(f -> haskey(data, String(f)), field_names)
+        if matched < length(_MODELCONFIG_REQUIRED_FIELDS)
+            error("$(path) does not look like a saved ModelConfig (only $(matched) " *
+                  "matching field keys; expected at least $(length(_MODELCONFIG_REQUIRED_FIELDS)) " *
+                  "required). Confirm this is a config file written by `save_config`, " *
+                  "not a trained-model file.")
+        end
+
+        kwargs = Dict{Symbol,Any}()
+        for fld in field_names
+            key = String(fld)
+            haskey(data, key) || continue
+            kwargs[fld] = data[key]
+        end
+        return ModelConfig(; kwargs...)
+    end
+
+    ## Internal: rebuild a ModelConfig from a (possibly Reconstructed) legacy object.
+    function _load_legacy_config(old, path::String)
+        type_name = string(typeof(old).name.name)
+        if !occursin("ModelConfig", type_name)
+            @warn "load_config: $(path) is in legacy save_object format but the stored " *
+                  "object type does not look like a ModelConfig (got $(type_name)). " *
+                  "Proceeding to copy whatever fields match by name."
+        end
+
+        kwargs = Dict{Symbol,Any}()
+        copied = 0
+        for fld in fieldnames(ModelConfig)
+            ## getproperty works on ReconstructedMutable for fields that exist in the
+            ## saved struct; we use try/catch instead of hasproperty because some JLD2
+            ## reconstruction wrappers do not override propertynames.
+            val = try
+                getproperty(old, fld)
+            catch
+                continue
+            end
+            kwargs[fld] = val
+            copied += 1
+        end
+
+        missing_required = [r for r in _MODELCONFIG_REQUIRED_FIELDS if !haskey(kwargs, r)]
+        if !isempty(missing_required)
+            error("Cannot construct ModelConfig from $(path): legacy file is missing " *
+                  "required field(s) $(missing_required). The file may be from a much " *
+                  "older Ronin version or may not be a ModelConfig at all.")
+        end
+
+        @info "load_config: $(path) is in legacy save_object format. Copied $(copied)/" *
+              "$(length(fieldnames(ModelConfig))) fields; defaults fill the rest. " *
+              "Re-save with `save_config(path, config)` to migrate to the dict-keyed " *
+              "format that survives future struct changes."
+
+        return ModelConfig(; kwargs...)
+    end
+
+    """
+        migrate_model_config(infile::String, outfile::String; key=nothing)
+
+    One-shot utility: load a legacy `save_object`-format ModelConfig file and re-save
+    it in the new dict-keyed format written by `save_config`. Returns the rebuilt
+    `ModelConfig`.
+
+    Migration is **not required for loading** — `load_config` reads legacy files
+    inline. Use this helper only when you want to upgrade a long-lived file on disk
+    so future loads skip the legacy path (and the deprecation `@info`).
+
+    `key` may be passed to select a specific JLD2 key when the file contains
+    multiple stored objects; defaults to the standard `single_stored_object` key
+    used by `JLD2.save_object`.
+    """
+    function migrate_model_config(infile::String, outfile::String; key=nothing)
+        config = if key === nothing
+            load_config(infile)
+        else
+            ## Caller specified a non-standard key — load that object and recover.
+            old = JLD2.load(infile, String(key))
+            _load_legacy_config(old, infile)
+        end
+        save_config(outfile, config)
+        @info "Migrated ModelConfig: $(infile) → $(outfile) (dict-keyed format)"
+        return config
     end
 
     """

--- a/test/unit_tests.jl
+++ b/test/unit_tests.jl
@@ -1456,6 +1456,150 @@ end
 end
 
 ###############################################################################
+# save_config / load_config — dict-keyed persistence (issue #34)
+###############################################################################
+@testset "save_config / load_config" begin
+    @testset "round-trip preserves field values" begin
+        cfg = make_config(num_models=2, input_path="/tmp/in",
+                          experiment_name="rt_test",
+                          task_mode="convolution",
+                          n_trees=37, max_depth=11,
+                          conv_variables=["DBZ", "VEL"],
+                          masked_conv_variables=["DBZ"],
+                          masked_conv_threshold=0.7f0)
+        path = joinpath(test_scratchspace, "config_roundtrip.jld2")
+        save_config(path, cfg)
+        @test isfile(path)
+        loaded = load_config(path)
+        @test loaded isa Ronin.ModelConfig
+        for fld in fieldnames(Ronin.ModelConfig)
+            @test getproperty(loaded, fld) == getproperty(cfg, fld)
+        end
+        ## Loaded config must be mutable — assigning fields is the core bug from #34.
+        loaded.task_paths = ["a", "b"]
+        @test loaded.task_paths == ["a", "b"]
+        rm(path; force=true)
+    end
+
+    @testset "missing keys fall back to defaults (forward-compat)" begin
+        ## Simulate an "older" save_config file by hand-writing only a subset of keys.
+        ## Future field additions to ModelConfig should load fine from such a file.
+        path = joinpath(test_scratchspace, "config_partial.jld2")
+        ## Symbol keys so `;partial...` becomes a kwarg splat for jldsave.
+        ## JLD2 serializes them as string keys on disk, which load_config reads back.
+        partial = Dict{Symbol,Any}(
+            :__ronin_config_format__ => "dict_v1",
+            :num_models              => 2,
+            :model_output_paths      => ["m1.jld2", "m2.jld2"],
+            :met_probs               => [(0.0f0, 1.0f0), (0.0f0, 0.99f0)],
+            :feature_output_paths    => ["f1.h5", "f2.h5"],
+            :input_path              => "/data",
+            :task_mode               => "convolution",
+            :file_preprocessed       => [false, false],
+            :n_trees                 => 99,
+        )
+        jldsave(path; partial...)
+        loaded = load_config(path)
+        @test loaded.n_trees == 99
+        @test loaded.num_models == 2
+        @test loaded.task_mode == "convolution"
+        ## A field not written should equal the struct's default.
+        default_cfg = make_config(num_models=2, input_path="/data", task_mode="convolution")
+        @test loaded.compute_feature_importance == default_cfg.compute_feature_importance
+        @test loaded.conv_kernel_sizes == default_cfg.conv_kernel_sizes
+        rm(path; force=true)
+    end
+
+    @testset "legacy save_object format is loadable inline" begin
+        ## Build a current ModelConfig, persist via save_object, reload via load_config.
+        ## (Same shape; this exercises the single_stored_object branch but does not
+        ## reproduce the cross-version field-mismatch on its own — see next testset.)
+        cfg = make_config(num_models=1, input_path="/legacy",
+                          experiment_name="legacy_test",
+                          task_mode="",
+                          n_trees=13, max_depth=7)
+        path = joinpath(test_scratchspace, "config_legacy.jld2")
+        JLD2.save_object(path, cfg)
+        loaded = load_config(path)
+        @test loaded isa Ronin.ModelConfig
+        @test loaded.n_trees == 13
+        @test loaded.max_depth == 7
+        @test loaded.num_models == 1
+        loaded.task_paths = ["from_legacy"]
+        @test loaded.task_paths == ["from_legacy"]
+        rm(path; force=true)
+    end
+
+    @testset "legacy file with extra/missing fields (cross-version simulation)" begin
+        ## Approximate Paul's situation: a saved struct that has fewer fields than the
+        ## current ModelConfig. We can't easily round-trip a foreign struct shape in
+        ## one process, so we exercise the recovery path by supplying a NamedTuple
+        ## standing in for the ReconstructedMutable.
+        old = (
+            num_models           = 2,
+            model_output_paths   = ["a.jld2", "b.jld2"],
+            met_probs            = [(0.0f0, 1.0f0), (0.0f0, 0.99f0)],
+            feature_output_paths = ["a.h5", "b.h5"],
+            input_path           = "/old",
+            task_mode            = "",
+            file_preprocessed    = [false, false],
+            task_paths           = Vector{Union{String,Vector{String}}}(["t1.txt", "t2.txt"]),
+            n_trees              = 7,
+            ## Note: no conv_variables, masked_conv_*, etc. — those should default.
+        )
+        rebuilt = Ronin._load_legacy_config(old, "synthetic.jld2")
+        @test rebuilt isa Ronin.ModelConfig
+        @test rebuilt.n_trees == 7
+        @test rebuilt.task_paths == Vector{Union{String,Vector{String}}}(["t1.txt", "t2.txt"])
+        ## New field gets the struct default, not garbage.
+        @test rebuilt.conv_variables == ["DBZ", "VEL"]
+        @test rebuilt.masked_conv_variables == String[]
+        ## Mutability check — the bug from #34 was setproperty! failing on the wrapper.
+        rebuilt.task_paths = ["new_path"]
+        @test rebuilt.task_paths == ["new_path"]
+    end
+
+    @testset "migrate_model_config writes loadable dict-keyed file" begin
+        cfg = make_config(num_models=1, input_path="/migrate",
+                          experiment_name="migrate_test",
+                          task_mode="",
+                          n_trees=21)
+        legacy = joinpath(test_scratchspace, "config_to_migrate.jld2")
+        new    = joinpath(test_scratchspace, "config_migrated.jld2")
+        JLD2.save_object(legacy, cfg)
+
+        migrated = migrate_model_config(legacy, new)
+        @test isfile(new)
+        @test migrated isa Ronin.ModelConfig
+
+        reloaded = load_config(new)
+        @test reloaded.n_trees == 21
+        @test reloaded.input_path == "/migrate"
+        ## Migrated file is the new format (no single_stored_object key).
+        keys_in_file = jldopen(new, "r") do f
+            collect(keys(f))
+        end
+        @test "num_models" in keys_in_file
+        @test !("single_stored_object" in keys_in_file)
+
+        rm(legacy; force=true)
+        rm(new; force=true)
+    end
+
+    @testset "load_config rejects non-config files" begin
+        ## A file containing only one or two unrelated keys should not load as a config.
+        path = joinpath(test_scratchspace, "not_a_config.jld2")
+        jldsave(path; some_other_key=42, another=[1, 2, 3])
+        @test_throws ErrorException load_config(path)
+        rm(path; force=true)
+    end
+
+    @testset "load_config errors clearly when file missing" begin
+        @test_throws ErrorException load_config("/nonexistent/path/config.jld2")
+    end
+end
+
+###############################################################################
 # Cleanup
 ###############################################################################
 @testset "Cleanup test scratch space" begin


### PR DESCRIPTION
Closes #34.

## Root cause

`ModelConfig` was being persisted via `JLD2.save_object`, which pickles the struct's *shape*. Every field added to `ModelConfig` thereafter breaks every previously-saved file: JLD2 deserializes the old payload as a read-only `ReconstructedMutable` shadow type, and any subsequent `setproperty!` (e.g. `curr_config.task_paths = [...]`) fails. That is exactly the #34 traceback.

## Fix

Two-part change so this stops happening on every struct evolution:

### 1. `save_config` / `load_config` (new persistence pattern)

- `save_config(path, config)` writes one JLD2 key per field. Adding a field later just means a new key for fresh files; old files still load.
- `load_config(path)` handles **both** formats transparently:
  - **Dict-keyed format** (new): fills any missing key with the struct's `@kwdef` default. Future field additions never break old files.
  - **Legacy `save_object` format** (Paul's existing files): copies each accessible field via `getproperty` into a fresh, mutable `ModelConfig`. New fields the saved file lacks are filled from defaults. Emits an `@info` once suggesting re-save, but does not require it.

This pattern matches what `load_model_with_metadata` already does for trained-model files (Dict-keyed with `get(data, key, default)`), so the codebase becomes consistent on persistence.

### 2. `migrate_model_config` (Isaac's original contribution, trimmed)

Kept as a one-shot utility for upgrading long-lived files on disk to the new format. Now a thin wrapper over `load_config` + `save_config` so the field-copy logic lives in one place (`_load_legacy_config`).

## What this means for existing users

- **Files saved with `JLD2.save_object(path, config)` keep working.** The only change in calling code is `JLD2.load_object(path)` → `Ronin.load_config(path)`. No on-disk migration required.
- **New training runs** should call `Ronin.save_config(path, config)` instead of `JLD2.save_object(...)`. Future ModelConfig field additions then become invisible to old loaders.
- **Optional cleanup:** `migrate_model_config(old, new)` re-saves a legacy file in the new format if you want to skip the deprecation `@info` on every load.

## Tests

New `@testset "save_config / load_config"` in `test/unit_tests.jl` covers:
- round-trip preserves all fields and yields a mutable struct
- missing keys fall back to struct defaults (forward-compat)
- legacy `save_object` format loads inline
- cross-version simulation via NamedTuple stand-in for `ReconstructedMutable`
- `migrate_model_config` produces a loadable dict-keyed file with no `single_stored_object` key
- non-config files and missing files error clearly

70 assertions, all passing locally.

## Review asks

- @irslushy: please confirm the trimmed `migrate_model_config` still does what you intended, and that `_load_legacy_config` correctly preserves your `key=` selection path for multi-key files.
- Recommend testing `Ronin.load_config(path_to_existing_old_config.jld2)` against a real legacy file before merging — confirm the loaded struct accepts field assignment.