### PR TITLE
Fix composite_QC / QC_scan / construct_next_pass_features for convolution task_mode

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -4,11 +4,17 @@ using Documenter, Ronin
 makedocs(sitename="Ronin.jl",
         modules= [Ronin],
         pages = [
-            "Home" => "index.md"
-            "Reference" => "api.md"
+            "Home"                      => "index.md",
+            "Concepts"                  => "concepts.md",
+            "Workflow Guide"            => "workflow.md",
+            "Convolution Feature Mode"  => "convolution.md",
+            "Legacy Hand-Tuned Mode"    => "legacy.md",
+            "Choosing a QC Entry Point" => "entrypoints.md",
+            "API Reference"             => "api.md",
         ],
-        format = Documenter.HTML(prettyurls = false), 
-        checkdocs=:none)
+        format = Documenter.HTML(prettyurls = false),
+        checkdocs=:exports,
+        checkdocs_ignored_modules=[Ronin.DecisionTree])
 
 deploydocs(;
     repo="github.com/csu-tropical/Ronin.jl.git",

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,41 +1,131 @@
-# Basic Workflow Walkthrough 
-RadarQC is a package that utilizes a methodology developed by [Dr. Alex DesRosiers and Dr. Michael Bell](https://journals.ametsoc.org/view/journals/aies/aop/AIES-D-23-0064.1/AIES-D-23-0064.1.xml) to remove non-meteorological gates from Doppler radar scans by leveraging machine learning techniques. In its current form, it contains functionality to derive a set of features from input radar data, use these features to train a Random Forest classification model, and apply this model to the raw fields contained within the radar scans. It also has some model evaluation ability. The beginning of this guide will walk through a basic workflow to train a model starting from scratch. 
+# API Reference
 
+Complete reference for Ronin's exported API, grouped by topic. See the
+[Concepts](concepts.md) and [Workflow Guide](workflow.md) pages for how these
+fit together.
 
+## Configuration
 
-# API / Function References 
+The `ModelConfig` struct is the single source of truth; the rest construct,
+persist, reload, and migrate it.
 
-## Model Configuration 
 ```@docs
 ModelConfig
+make_config
+save_config
+load_config
+migrate_model_config
 ```
-## Calculating Model Input Features
+
+## Data preparation
+
+Splitting cfradial directories into train/test/(validation) sets and related
+directory utilities.
 
 ```@docs
-calculate_features(::String, ::String, ::String, ::Bool)
 split_training_testing!
-train_model(::String, ::String)
+split_training_testing_validation!
 remove_validation
-get_feature_importance(::String, ::Vector{Float64})
+parse_directory
 ```
 
-## Applying and evaluating a trained model to data
+## Feature calculation — convolution mode
+
+The recommended feature regime: a kernel bank convolved over `conv_variables`.
 
 ```@docs
-QC_scan
-characterize_misclassified_gates
+calculate_features_conv
+ConvolutionKernel
+build_kernel_bank
+compute_convolution_features
+masked_convolve
+get_convolution_feature_count
 ```
 
-## Predicting using a composite model
+## Feature calculation — legacy hand-tuned mode
+
+The v1.1.0 hand-crafted predictor pipeline and its spatial reducers.
 
 ```@docs
-train_multi_model
-composite_prediction
-```
-
-## Non-user facing
-
-```@docs
-get_task_params
+calculate_features
 process_single_file
+get_task_params
+get_num_tasks
+calc_avg
+calc_std
+calc_iso
+airborne_ht
+prob_groundgate
+```
+
+## Training
+
+Fitting Random Forest classifiers, single-pass and multi-pass.
+
+```@docs
+train_model
+train_multi_model
+train_single_pass
+```
+
+## Multi-pass masking
+
+Generating and regenerating the inter-pass met-prob masks.
+
+```@docs
+generate_pass_masks
+regenerate_masks
+```
+
+## Feature importance / selection
+
+Permutation and RF-native importance, and feature subsetting.
+
+```@docs
+compute_importance
+get_feature_importance
+select_features
+compute_rf_feature_importance
+```
+
+## Hyperparameter tuning
+
+Sweeping RF hyperparameters and inter-pass thresholds.
+
+```@docs
+run_hypertuning
+sweep_pass2_met_probs
+```
+
+## Prediction & QC
+
+Applying a trained cascade to radar data. See
+[Choosing a QC Entry Point](entrypoints.md) for which to use.
+
+```@docs
+composite_prediction
+composite_QC
+QC_scan
+write_field
+```
+
+## Evaluation & inspection
+
+Scoring models and inspecting saved model files.
+
+```@docs
+evaluate_model
+run_evaluation
+get_contingency
+compute_auc_roc
+met_prob_histogram
+characterize_misclassified_gates
+inspect_model_configuration
+load_model_with_metadata
+```
+
+## Utilities
+
+```@docs
+compute_balanced_class_weights
 ```

--- a/docs/src/concepts.md
+++ b/docs/src/concepts.md
@@ -1,0 +1,88 @@
+# Concepts
+
+This page is the shared mental model behind Ronin. It applies to both feature
+modes (convolution and legacy hand-tuned).
+
+## Gates and the classification problem
+
+A radar sweep is a grid of **gates** (range × time/azimuth). Each gate is
+either **meteorological** (real weather echo we want to keep) or
+**non-meteorological** (ground clutter, noise, sidelobes — we want to remove
+it). Ronin trains a Random Forest to make that binary call per gate, then
+blanks the non-meteorological gates in the raw fields.
+
+### MD / NMD label convention
+
+- **Meteorological data (MD)** is `1` / `true`.
+- **Non-meteorological data (NMD)** is `0` / `false`.
+
+This convention holds everywhere: training targets, predictions, masks.
+
+## `ModelConfig` is the single source of truth
+
+Ronin is built around one configuration struct, [`ModelConfig`](@ref).
+Everything needed to define, train, evaluate, and apply a QC model lives in it:
+data paths, the number of cascade passes, feature settings, RF hyperparameters,
+per-pass thresholds, and QC output variables. Construct it with
+[`make_config`](@ref) (which auto-derives paths and `mask_names`), persist it
+with [`save_config`](@ref), and reload it with [`load_config`](@ref).
+
+`config.task_mode` selects the feature regime — `"convolution"` for the
+recommended kernel-bank mode, `""` for the legacy hand-tuned predictors. The
+behavior is **not** agnostic to this value; it branches across training,
+prediction, QC, and mask generation.
+
+## The pipeline: features → RF → met-prob → mask
+
+For each pass:
+
+1. **Features** are computed per gate (a kernel bank in convolution mode, or
+   hand-tuned spatial predictors in legacy mode).
+2. A **Random Forest** is trained / applied to those features.
+3. The RF emits a **meteorological probability** per gate — the model's
+   confidence that the gate is weather. In training this is written back into
+   the CfRadial files as `met_prob_pass_<N>`.
+4. A **mask** is derived by keeping gates whose met-prob falls in the pass's
+   `(low, high)` threshold window.
+
+## The multi-pass cascade
+
+`num_models` sets the number of passes. With `num_models > 1`, each pass after
+the first only sees the gates that survived the previous pass's mask. Pass `i`
+(for `i < num_models`) writes `met_prob_pass_<i>` and the mask
+`mask_names[i+1]`; the next pass trains/predicts only within that mask. This
+lets later passes specialize on the harder, ambiguous gates.
+
+- `met_probs::Vector{Tuple{Float32,Float32}}` — one `(low, high)` window per
+  pass.
+- `mask_names` — default `["mask_pass_0", "mask_pass_1", ...]` from
+  `make_config`; `mask_pass_0` is the (empty) starting mask.
+
+Two passes is the recommended starting point.
+
+## `FILL_VAL` and missing data
+
+Missing / blanked gates are represented by `Ronin.FILL_VAL`
+(`typemin(Int16) = -32768`). Windowed spatial reducers exclude `missing` gates
+from their neighbourhoods; a fully-missing window collapses to `FILL_VAL`.
+
+## Variable name glossary
+
+Ronin works with multiple radar conventions. The QC'd (interactively edited)
+fields serve as ground truth for training.
+
+**ELDORA**
+
+| Quantity | Raw | QC'd (ground truth) |
+|---|---|---|
+| Velocity | `VV` | `VG` |
+| Reflectivity | `ZZ` | `DBZ` |
+| Signal quality (NCP) | `NCP` | — |
+
+**NOAA TDR**
+
+| Quantity | Raw | QC'd (ground truth) |
+|---|---|---|
+| Velocity | `VEL` | `VE` |
+| Reflectivity | `DBZ` | `DZ` |
+| Signal quality (SQI) | `SQI` | — |

--- a/docs/src/convolution.md
+++ b/docs/src/convolution.md
@@ -1,0 +1,99 @@
+# Convolution Feature Mode
+
+Set `task_mode = "convolution"`. This is the recommended feature regime as of
+1.2.0. Instead of a hand-tuned predictor file, features are derived by
+convolving a **kernel bank** over a set of radar variables.
+
+## Kernel bank
+
+A [`ConvolutionKernel`](@ref) is a named `Matrix{Float32}` of weights.
+[`build_kernel_bank`](@ref)`(kernel_sizes)` builds the bank: for each size `k`
+it adds a `mean_<k>x<k>` kernel; it always adds `laplacian_3x3`,
+`sobel_range_3x3`, and `sobel_azi_3x3`; and for each `k ≥ 5` it adds a
+`gaussian_<k>x<k>`.
+
+With the default `conv_kernel_sizes = [3, 5, 7]` this yields **8 kernels**:
+`mean_3`, `mean_5`, `mean_7`, `laplacian_3x3`, `sobel_range_3x3`,
+`sobel_azi_3x3`, `gaussian_5x5`, `gaussian_7x7`.
+
+## Feature layout
+
+[`compute_convolution_features`](@ref) produces, per *conv-variable × kernel*,
+**two columns**:
+
+- `<var>_<kern>` — the convolved value.
+- `<var>_<kern>_vfrac` — the valid (non-missing) fraction within the kernel
+  footprint.
+
+If a met-prob mask is supplied, the experimental masked-convolution columns are
+appended next (see below). Finally, **four scalar features are appended, in this
+order: AHT, ELV, RNG, NRG**.
+
+The total feature count is given by
+[`get_convolution_feature_count`](@ref):
+
+```
+n_vars * n_kernels * 2  +  n_masked_vars * n_masked_kernels * 2  +  4
+```
+
+## `conv_variables`
+
+`config.conv_variables` lists the inputs the kernel bank operates on. The
+resolver (`load_conv_variable`) accepts:
+
+- Raw CfRadial fields (e.g. `"DBZ"`, `"VEL"`, `"WIDTH"`).
+- Derived variables `PGG` (probability of ground gate) and `SIG` (signal
+  quality).
+- Spatial reducers `AVG(var)`, `ISO(var)`, `STD(var)` — resolved recursively,
+  so `ISO(PGG)` works.
+- Prior-pass output `met_prob_pass_<N>` (used by cascade pass `N+1`).
+
+`conv_variables` can differ per pass via `PASS_CONFIG` — a common pattern is to
+append `"met_prob_pass_1"` to Pass 2's variables.
+
+## Computing features
+
+[`calculate_features_conv`](@ref)`(config, output_file; …)` is the
+convolution-mode replacement for `calculate_features`. In the workflow this is
+driven by `02_train.jl` / `run_workflow.jl`; you rarely call it directly.
+
+## Feature selection / importance
+
+Training on all features then computing permutation importance
+([`compute_importance`](@ref)) writes `recommended_features` (and
+`importances`) into the model's JLD2. Inspect with
+[`inspect_model_configuration`](@ref), set `config.selected_features` to the
+recommended indices, and retrain.
+
+Note: you must **retrain** on the selected feature subset — you cannot train on
+N features and prune to K at inference, because the Random Forest's tree splits
+reference specific column indices. The model's `selected_features` is reloaded
+at inference so the feature matrix matches what the trees expect.
+
+## Met-prob-masked convolutions
+
+!!! warning "Experimental"
+
+    Met-prob-masked convolutions are experimental and may be revisited or
+    changed in a future release. They are **not** part of the recommended
+    workflow path. Enable them only if you are deliberately experimenting.
+
+When enabled, an additional set of convolution columns is computed where the
+kernel only accumulates contributions from neighbours that the previous pass
+considered meteorological. [`masked_convolve`](@ref) distinguishes the *valid*
+set (which gates get an output) from the *neighbor mask* (valid ∧ met-prob
+mask — which gates contribute to the sum).
+
+Configuration fields:
+
+- `masked_conv_variables` — variables to compute masked-conv columns for.
+- `masked_conv_kernel_types` — subset of
+  `{mean, gaussian, laplacian, sobel_range, sobel_azi}`.
+- `masked_conv_kernel_sizes` — kernel sizes.
+- `masked_conv_threshold` — met-prob cutoff (default `0.1f0`).
+- `masked_conv_met_prob_field` — which `met_prob_pass_<N>` field to mask with.
+
+The filtered kernel bank is the Cartesian product of types × sizes, with the
+same structural constraints as the main bank (`laplacian`/`sobel` only at
+`k == 3`, `gaussian` only at `k ≥ 5`); other combinations are silently skipped
+and the skipped set is reported once at training time.

--- a/docs/src/entrypoints.md
+++ b/docs/src/entrypoints.md
@@ -1,0 +1,49 @@
+# Choosing a QC Entry Point
+
+Three functions can apply a trained model to radar data. They differ in **what
+you hand them** and **what workflow they fit**. All three honor
+`config.task_mode` (convolution or legacy) and the multi-pass cascade. All
+three produce identical QC results for the same model and data — the choice is
+about control flow and what you get back, not accuracy.
+
+## `QC_scan(config::ModelConfig)` — the default entry point
+
+Config-and-directory driven. It reads `config.input_path` (a directory or a
+single CfRadial) and internally calls
+`composite_prediction(config; QC_mode=true)`, writing QC'd fields
+(`<var><QC_SUFFIX>` for each `config.VARS_TO_QC`) back into the files. Use this
+for the normal "I trained a model, now clean this dataset" case. This is what
+`workflow/06_qc.jl` uses. **Start here** unless you have a specific reason not
+to.
+
+## `composite_prediction(config; …)` — the analysis / evaluation engine
+
+Same cascade inference as `QC_scan`, but it **returns**
+`(predictions, verification, indexers, pass_probs)` and only writes QC'd fields
+if you pass `QC_mode=true`. Reach for this when you want the predictions and
+probabilities in memory — building metrics, plotting met-prob distributions,
+comparing thresholds, or any programmatic analysis where you don't (yet) want
+to mutate the CfRadials. It also backs [`run_evaluation`](@ref). Pass
+`skip_existing_met_probs=true` to reuse previously written `met_prob_pass_<i>`
+fields instead of recomputing features (much faster for re-scoring).
+
+## `composite_QC(config, files::Vector{String}[, models])` — the streaming / operational entry point
+
+Driven by an **explicit vector of file paths**, not `config.input_path`. It
+runs each cascade pass file-by-file, writing `met_prob_pass_<i>` and
+`mask_pass_<i+1>` between passes, then writes QC'd fields. The 2-arg form loads
+the random forests internally from `config.model_output_paths`; the 3-arg form
+takes preloaded `models` (load once, QC many files). This is the right tool for
+realtime / aircraft-side pipelines and any driver that already has a file list
+and a `ModelConfig` reloaded via
+`load_config("model_config_<EXPERIMENT_NAME>.jld2")`. See
+`REALTIME/Ronin_realtime.jl` for a worked operational example.
+
+## Decision shortcut
+
+- Cleaning a directory you've pointed `config.input_path` at →
+  `QC_scan(config)`.
+- Need predictions/probabilities in memory, or computing metrics →
+  `composite_prediction(config; …)` (or `run_evaluation`).
+- Operational/streaming loop over an explicit file list, models loaded once →
+  `composite_QC(config, files, models)`.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,162 +1,67 @@
+# Ronin.jl
 
-Ronin (Random forest Optimized Nonmeteorological IdentificatioN) is a package that utilizes a methodology developed by [Dr. Alex DesRosiers and Dr. Michael Bell](https://journals.ametsoc.org/view/journals/aies/aop/AIES-D-23-0064.1/AIES-D-23-0064.1.xml) to remove non-meteorological gates from Doppler radar scans by leveraging machine learning techniques. In its current form, it contains functionality to derive a set of features from input radar data, use these features to train a Random Forest classification model, and apply this model to the raw fields contained within the radar scans. It also has some model evaluation ability. The beginning of this guide will walk through a basic workflow to train a model starting from scratch.  
+**Ronin** (Random forest Optimized Nonmeteorological IdentificatioN) removes
+non-meteorological gates from Doppler radar scans using the machine-learning
+methodology of [Dr. Alex DesRosiers and Dr. Michael
+Bell](https://journals.ametsoc.org/view/journals/aies/aop/AIES-D-23-0064.1/AIES-D-23-0064.1.xml).
+It derives features from raw radar data, trains a Random Forest classifier on
+them, and applies that model to clean the raw fields in radar scans, with
+built-in evaluation tooling.
 
-# Package Philosophy 
-Ronin is written around a single model configuration struct, typed as `ModelConfig`. More documentation can be found in the API. All options necessary to define, train, and use a quality control model are contained wihthin it. 
+If you use Ronin in published work, please cite DesRosiers and Bell (2023),
+*Artificial Intelligence for the Earth Systems*.
 
-# Single-model Workflow Walkthrough 
+## Installation
 
-![Roninflowchart](./imgs/Ronin_flowchart.png)
-
-## Preparing input data 
-
----
-
-The first step in the process is to split our data so that some of it may be utilized for model training and the other portion for model testing. It's important to keep the two sets separate, otherwise the model may overfit. 
-
-The basic requirement here is to have a directory or directories of cfradial scans, and two directories to put training and testing files, respectively. Make sure that no other files are present in these directories. To do this, the [`split_training_testing!`](https://github.com/irslushy/Ronin.jl/tree/main/src/Ronin.jl#943) function will be used. For example, if one had two cases of radar data, located in `./CASE1/` and `./CASE2/` and wanted to split into `./TRAINING` and `./TESTING`, execute the command 
-
-```julia
-split_training_testing(["./CASE1", "./CASE2"], "./TRAINING", "./TESTING")
-```
-
-More information about this function is contained within the docs. 
-
---- 
-
-Now that we have split the input files, we can proceed to calculate the features used to train and test our Random Forest model. Further details are contained within the aforementioned manuscript, but it has been shown that the parameters contained [here](https://github.com/irslushy/Ronin.jl/blob/259aa4d306e09fedf9d4208bcc8a584fbabd89a2/MODELS/DesRosiers_Bell_23/config.txt) are most effective for discriminating between meteorological/non-meteorological gates. For this, we will use the [calculate_features](https://github.com/irslushy/Ronin.jl/tree/main/src/Ronin.jl#L265) function. Since we are calculating features to **train** a model at this point, we will assume that intreactive QC has already been applied to them. To get the most skillful model possible, we will want to remove "easy" cases from the training set, so set `REMOVE_LOW_NCP=true` and `REMOVE_HIGH_PGG=true` to ignore data not meeting minimum quality thresholds. It's also important to specify which variable contained with the input scans has already been QC'ed - in the ELDORA scans, this is `VG`. `missing` values must also be removed from the initial training set, so we'll use a raw variable `VV` to determine where these gates are located. With that said, one may now invoke 
+Ronin is in the Julia General Registry:
 
 ```julia
-calculate_features("./TRAINING", "./config.txt", "TRAINING_FEATURES.h5", true;
-                    verbose=true, REMOVE_LOW_NCP = true, REMOVE_HIGH_PGG=true,
-                    QC_variable="VG", remove_variable="VV")
+using Pkg
+Pkg.add("Ronin")
 ```
 
-To use the config file located at `./config.txt` to output the training features to `TRAINING_FEATURES.h5`. 
+## Fastest path
 
-For clarity's sake, for the testing features this step would be exectued again but changing the input directory and output location. 
-
-This is a somewhat computationally expensive process for large datasets >1000 scans, and so can take over 15 minutes. 
-
----
-
-## Training a Random Forest Model 
----
-
-Now that the somewhat arduous process of calculating input features has completed, it's time to train our model! We'll use the **training** set for this, which we have previously defined to be located at `./TRAINING_FEATURES.h5`. 
-
-First, in order to combat the class imbalance problem, we must calculate weights for the non-meteorological and meteorological gates. This can be achieved as follows.
+The recommended way to train and apply a model is the shipped `workflow/`
+pipeline. From a clone of the repository:
 
 ```julia
-weights = Vector{Float64}(undef, 0)
-class_weights = h5open("TRAINING_FEATURES.h5") do f
-    samples = f["Y"][:,:][:]
-    class_weights = Vector{Float32}(fill(0,length(samples)))
-    weight_dict = compute_balanced_class_weights(samples)
-
-    for class in keys(weight_dict) 
-        class_weights[samples .== class] .= weight_dict[class]
-    end 
-    return(class_weights)
-end 
+# edit workflow/00_config.jl (experiment name, data paths, model params)
+julia --threads=auto workflow/01_split_data.jl   # one-time train/test/val split
+julia --threads=auto workflow/02_train.jl        # train the multi-pass cascade
+julia --threads=auto workflow/02a_evaluate.jl    # evaluate on the testing set
+julia --threads=auto workflow/06_qc.jl           # write QC'd fields
 ```
 
-Now we can train the model! 
+See the [Workflow Guide](workflow.md) for the full pipeline, the
+[Concepts](concepts.md) page for the mental model, and [Choosing a QC Entry
+Point](entrypoints.md) if you are integrating Ronin into your own driver.
 
-```julia
-train_model("./TRAINING_FEATURES.h5", "TRAINED_MODEL.joblib"; class_weights = Vector{Float32}(class_weights) , verify=true, verify_out="TRAINING_SET_VERIFICATION.h5")
-```
+## What changed in 1.2.0
 
-This will train a model based off the information contained within `TRAINING_FEATURES.h5`, saving it for further use at `./TRAINED_MODEL.joblib`. The `verify` keyword arguments means that, once trained, the model will be automatically applied to the training dataset and the predictions will be output, along with the ground truth/correct answers, to the h5 file at `TRAINING_SET_VERIFICATION.h5`.   
+Version 1.2.0 is the first Julia General Registry release. The documentation
+below now covers the full current surface; the legacy single-model,
+hand-tuned-predictor flow is preserved on the [Legacy Hand-Tuned
+Mode](legacy.md) page but is no longer the recommended path. Highlights of the
+1.1.0 → 1.2.0 delta (see `CHANGELOG.md` for the authoritative list):
 
+- **Convolution feature mode** (`task_mode = "convolution"`) — a kernel bank
+  replaces the hand-crafted predictor file as the recommended feature set.
+- **Multi-pass cascade** — `train_multi_model` / `composite_prediction` /
+  `composite_QC`, with per-pass `met_probs`, `mask_names`, and
+  `selected_features`.
+- **Met-prob-masked convolutions** — optional and *experimental*.
+- **Hyperparameter and Pass-2 threshold sweeps** — `run_hypertuning`,
+  `sweep_pass2_met_probs`.
+- **Permutation feature importance** — `compute_importance`.
+- **Robust config persistence** — `save_config` / `load_config` survive future
+  `ModelConfig` field additions (fixes #34).
+- **Workflow scripts** — the `workflow/` directory and `run_workflow.jl`
+  orchestrator, with auto-persisted `model_config_<EXPERIMENT_NAME>.jld2`.
+- **Validation-set splitting** — `split_training_testing_validation!`.
 
----
-## Applying the trained model to a radar scan   
----
-  
-
-
-It's finally time to begin cleaning radar data! We'll use the `QC_scan` function to apply our model to raw moments. Let's imagine we want to clean the scan located at `./cfrad_example_scan` using the model we previously trained at `TRAINED_MODEL.joblib`. By default, this will clean the variables with the names `ZZ` and `VV`, though this can be changed by modifying the `VARIABLES_TO_QC` argument. They will be added to the cfradial file with the names `ZZ_QC` and `VV_QC`, respectively, though this suffix can be changed though keyword arguments. Execute as  
-
-```
-QC_scan("./cfrad_example_scan", "./config.txt", "./TRAINED_MODEL.joblib")
-```
-
----
-## Spatial Predictors Reference 
----
-
-A key portion of this methodology is deriving "predictors" from raw input radar moments. Raw moments include quantities such as Doppler velocity and reflectivity, while derived variables include things such as the standard deviation of a raw moment across a set of azimuths and ranges in a radar scan. Calculating these features allows the addition of spatial context to the classification problem even when only classifying a single gate. 
-
-Each of the spatial predictors (Currently STD, ISO, and AVG) have predefined "windows" that specify the area they calculate. These windows are specified as matrixes at the top of [RoninFeatures.jl](https://github.com/irslushy/Ronin.jl/blob/main/src/RoninFeatures.jl). They can also be user specified when using [calculate_features](https://irslushy.github.io/Ronin.jl/dev/api.html#Ronin.calculate_features-Tuple{String,%20Vector{String},%20Vector{Matrix{Union{Missing,%20Float64}}},%20String,%20Bool}). &nbsp;
-
-
-### Currently Implemented Functions:   
-
-#### **STD(VAR)**
---- 
-Calculates the standard deviation of each gate of the variable with name VAR in the given radar sweep. By default, gates that contain `missing` values are ignored in this calculation. Further by default 
-
----
-
-#### **ISO(VAR)**
---- 
-Calculates the "isolation" of each gate of the variable with name VAR in the given radar sweep. This calculation sums the number of adjacent gates in both range and aziumth that contain `missing` values. 
-
----
-#### **AVG(VAR)**
----
-Calculates the average of each gate of the variable with name VAR in the given radar sweep. By default, gates that contain `missing` values are ignored in this calculation. 
-
----
-#### **RNG/NRG**
----
-Calculates the range of all radar gates (RNG) from the airborne platform, or normalized by altitude (NRG). 
-
----
-#### **PGG**
-**P**robability of **G**round **G**ate - a geometric calculation that gives the probability that a given radar gate is a result of reflection from the ground. 
-___
-
-
-#### **AHT**
-**A**ircraft **H**eigh**T** - calculates platform height while factoring in Earth curvature. 
-______
-
-
-### **Implementing a new parameter**
-
-The code is written in such a way that it would hopefully be relatively easy for a user to add a function of their own to apply to radar data. One could go about this using the following as a guide.    
-
-
-There are two types of functions in Ronin: Those that act on radar variables (STD, AVG) and those that operate relatively independent of them (RNG, PGG). Functions that act on variables must be defined using a **3 letter abbreviation** and begin with `calc_`. Furthermore, the function should take **1 positional** and **2 keyword** arguments. The positional argument should be the variable in matrix form to operate upon. The keyword arguments should be `weights` and `window`, where both have the same dimensions. `window` specifies the area for the spatial parameter to take for each gate, and `weights` specifies how much weight to give each neighboring gate. For example, if we wanted to define a function that gave us the logartihm of a variable, we could name it `LOG`, with the function defined in code as
-
-```
-function calc_LOG(var::Matrix{Union{Missing, Float64}}; weights=default_weights, window=default_window)
-```
-
-The function should return an array of the same size as `var`. 
-
-Finally, add the three letter abbreviation `LOG` to the `valid_funcs` array at the top of `RoninFeatures.jl`. 
-
-Congratulations! You've added a new function! 
-
----
-## Data Conventions/Glossary 
----
-Some important data convetions to make note of: 
-
-* **Meteorological Data is referred to by 1 or `true`**
-* **Non-Meteorological Data is referred to by 0 or `false`**
-* **ELDORA** scan variable names: 
-    * Raw Velocity: **VV**
-    * QC'ed Velocity (Used for ground truth): **VG**
-    * Raw Reflectivity: **ZZ**
-    * QC'ed Reflectivity (Used for ground truth): **DBZ**
-    * Normalized Coherent Power/Signal Quality Index: **NCP**
-* **NOAA TDR** scan variable names: 
-    * Raw Velocity: **VEL**
-    * QC'ed Velocity (Used for ground truth): **VE**
-    * Raw Reflectivity: **DBZ**
-    * QC'ed Reflectivity (Used for ground truth): **DZ**
-    * Normalized Coherent Power/Signal Quality Index: **SQI**
+Non-breaking deprecations: the v1.1.0 `REMOVE_LOW_NCP` keyword and
+`ModelConfig.REMOVE_LOW_NCP` field still work but emit a deprecation warning;
+use `REMOVE_LOW_SIG_QUALITY`. Breaking removals: `predict_with_model` and the
+3-arg `evaluate_model(::String, ::String, ::String)` are gone — use
+`composite_prediction`, `run_evaluation`, or `QC_scan`.

--- a/docs/src/legacy.md
+++ b/docs/src/legacy.md
@@ -1,0 +1,144 @@
+# Legacy Hand-Tuned Mode
+
+Before the convolution feature mode, Ronin used a hand-crafted predictor file
+and a single Random Forest. This mode is **fully preserved** but is no longer
+the recommended path — new work should use the
+[Convolution Feature Mode](convolution.md). Select it by leaving
+`task_mode = ""` (any value other than `"convolution"`) and supplying
+`task_paths` / `task_weights` (or, in the single-model API, a `config.txt`
+predictor file).
+
+## Legacy single-model walkthrough
+
+This is the original v1.1.0 flow, condensed.
+
+### 1. Split the data
+
+You need one or more directories of cfradial scans and separate output
+directories for training and testing files. [`split_training_testing!`](@ref)
+softlinks files into them:
+
+```julia
+split_training_testing!(["./CASE1", "./CASE2"], "./TRAINING", "./TESTING")
+```
+
+(Use [`split_training_testing_validation!`](@ref) for a three-way split with a
+held-out validation set.)
+
+### 2. Calculate features
+
+Use [`calculate_features`](@ref) with a predictor `config.txt`. Because we are
+computing features to **train** a model, interactive QC is assumed already
+applied; the QC'd variable is the ground truth (ELDORA: `VG`). To get the most
+skillful model, drop "easy" cases with `REMOVE_LOW_SIG_QUALITY = true` and
+`REMOVE_HIGH_PGG = true`, and remove `missing` gates using a raw variable:
+
+```julia
+calculate_features("./TRAINING", "./config.txt", "TRAINING_FEATURES.h5", true;
+                    verbose=true, REMOVE_LOW_SIG_QUALITY = true, REMOVE_HIGH_PGG = true,
+                    QC_variable="VG", remove_variable="VV")
+```
+
+!!! note "Deprecated keyword"
+
+    The v1.1.0 keyword `REMOVE_LOW_NCP` still works (in `calculate_features`,
+    `process_single_file`, and `make_config`, plus the
+    `ModelConfig.REMOVE_LOW_NCP` field) but emits a deprecation warning and
+    forwards to `REMOVE_LOW_SIG_QUALITY`. Use the new name.
+
+Repeat for the testing set with the testing directory and a different output
+path. For large datasets (>1000 scans) this can take 15+ minutes.
+
+### 3. Train the model
+
+Combat class imbalance by computing per-sample weights, then train:
+
+```julia
+class_weights = h5open("TRAINING_FEATURES.h5") do f
+    samples = f["Y"][:,:][:]
+    cw = Vector{Float32}(fill(0, length(samples)))
+    weight_dict = compute_balanced_class_weights(samples)
+    for class in keys(weight_dict)
+        cw[samples .== class] .= weight_dict[class]
+    end
+    return cw
+end
+
+train_model("./TRAINING_FEATURES.h5", "TRAINED_MODEL.joblib";
+            class_weights = Vector{Float32}(class_weights),
+            verify=true, verify_out="TRAINING_SET_VERIFICATION.h5")
+```
+
+`verify=true` applies the freshly trained model back to the training set and
+writes predictions plus ground truth to the verification HDF5.
+
+### 4. Apply the model
+
+```julia
+QC_scan("./cfrad_example_scan", "./config.txt", "./TRAINED_MODEL.joblib")
+```
+
+By default this cleans `ZZ` and `VV`, writing `ZZ_QC` / `VV_QC` (configurable
+via the variables-to-QC argument and the QC suffix).
+
+## Spatial Predictors Reference
+
+!!! note
+
+    These predictors are the feature set for the **legacy hand-tuned mode**
+    (`task_mode = ""`). Convolution mode derives its own features from a kernel
+    bank — see the [Convolution Feature Mode](convolution.md) page.
+
+A key part of this methodology is deriving "predictors" from raw moments. Raw
+moments are quantities like Doppler velocity and reflectivity; derived
+variables add spatial context (e.g. the standard deviation of a moment over a
+window of azimuths and ranges), letting the classifier reason spatially even
+when labelling a single gate.
+
+Each spatial predictor (STD, ISO, AVG) has a predefined **window** specifying
+the area it covers, declared as a matrix at the top of `RoninFeatures.jl`. The
+window/weights can also be user-specified through `calculate_features`.
+
+### Currently implemented functions
+
+**`STD(VAR)`** — standard deviation of the named variable at each gate. Gates
+containing `missing` are ignored by default.
+
+**`ISO(VAR)`** — "isolation": sums the number of adjacent gates in range and
+azimuth that contain `missing`.
+
+**`AVG(VAR)`** — average of the named variable at each gate; `missing` gates
+ignored by default.
+
+**`RNG` / `NRG`** — range of all gates from the airborne platform (`RNG`), or
+that range normalized by altitude (`NRG`).
+
+**`PGG`** — **P**robability of **G**round **G**ate; a geometric calculation of
+the probability that a gate is a reflection from the ground.
+
+**`AHT`** — **A**ircraft **H**eigh**T**; platform height accounting for Earth
+curvature.
+
+### Implementing a new predictor
+
+The code is structured so adding your own predictor is straightforward. There
+are two kinds of functions: those that act on a radar variable (STD, AVG) and
+those that operate independently of one (RNG, PGG).
+
+A variable function must use a **3-letter abbreviation**, be named `calc_<abbr>`
+(lowercase), and take **1 positional** and **2 keyword** arguments: the
+positional argument is the variable matrix to operate on; the keywords are
+`weights` and `window`, both the same dimensions. `window` is the per-gate
+footprint; `weights` is the per-neighbour weight. For example, a log predictor
+named `LOG`:
+
+```julia
+function calc_LOG(var::Matrix{Union{Missing, Float64}};
+                  weights=default_weights, window=default_window)
+    # ... return an array the same size as `var`
+end
+```
+
+Finally, add the 3-letter abbreviation (`LOG`) to the `valid_funcs` array at
+the top of `RoninFeatures.jl`. The new predictor is now usable in a
+`config.txt`.

--- a/docs/src/workflow.md
+++ b/docs/src/workflow.md
@@ -1,0 +1,127 @@
+# Workflow Guide
+
+The `workflow/` directory is the **recommended** way to use Ronin. It is a set
+of small, ordered scripts that all share one in-memory `config::ModelConfig`
+defined in `00_config.jl`. You edit configuration in exactly one place, then run
+the stages you need.
+
+Every script begins with `include("00_config.jl")`. Run them with threads
+enabled:
+
+```julia
+julia --threads=auto workflow/02_train.jl
+```
+
+## The scripts
+
+| Script | Purpose |
+|---|---|
+| `00_config.jl` | Shared configuration — *included by every other script*. Edit here. |
+| `01_split_data.jl` | One-time `split_training_testing_validation!(CASE_PATHS, …)`. |
+| `02_train.jl` | `train_multi_model(config)` on **all** features. |
+| `02a_evaluate.jl` | `inspect_model_configuration` + `run_evaluation` on the testing set (optionally validation). No retraining. |
+| `03_importance.jl` | `compute_importance(config)`; rewrites the JLD2 with `recommended_features` and prints indices to paste into `SELECTED_FEATURES`. |
+| `04_retrain.jl` | `train_multi_model(config)` with the pruned `selected_features` (errors if empty). |
+| `05_sweep_pass2.jl` | `sweep_pass2_met_probs(…)` — freeze Pass 1, sweep Pass 2 `met_prob` thresholds (errors if `num_models < 2`). |
+| `06_qc.jl` | Points `config.input_path` at `QC_PATH`, sets `config.met_probs`, calls `QC_scan(config)` to write QC'd fields. |
+| `run_workflow.jl` | Single orchestrator that runs any subset of the above in order, via boolean flags. |
+| `kitchen_sink_config.jl` | A worked-example alternative to `00_config.jl` (a real `selected_features` list, finer sweep grids). |
+
+A typical first run: `01_split_data.jl` → `02_train.jl` → `02a_evaluate.jl` →
+`03_importance.jl` → set `SELECTED_FEATURES` → `04_retrain.jl` →
+(optionally `05_sweep_pass2.jl`) → `06_qc.jl`.
+
+## `00_config.jl` sections
+
+This file is organized into clearly delimited sections. The fields you actually
+edit are:
+
+- **S1 — Experiment.** `EXPERIMENT_NAME`, `EXPERIMENT_NOTES`. The name drives
+  auto-generated paths and the persisted `model_config_<EXPERIMENT_NAME>.jld2`.
+- **S2 — Data paths.** `CASE_PATHS` (input cfradial directories),
+  `TRAINING_PATH`, `TESTING_PATH`, `VALIDATION_PATH`.
+- **S3 — Model parameters.**
+  - `num_models` (cascade passes; 2 recommended).
+  - `met_probs_train` / `met_probs_test` — per-pass `(low, high)` thresholds.
+  - Signal-quality filtering: `SIG_QUALITY_VAR_NAME`,
+    `SIG_QUALITY_THRESHOLD`, `REMOVE_LOW_SIG_QUALITY`.
+  - PGG ground-gate filtering: `REMOVE_HIGH_PGG`, `PGG_THRESHOLD`.
+  - RF hyperparameters: `n_trees`, `max_depth`, `class_weights`,
+    `max_training_threads`.
+  - Feature mode: `task_mode` and (for convolution) `conv_variables`,
+    `conv_kernel_sizes`, `feature_importance_threshold`,
+    `n_importance_repeats`, `importance_subsample_fraction`.
+  - `PASS_CONFIG` — per-pass overrides (`conv_variables`,
+    `selected_features`, and the experimental masked-conv block).
+  - QC output: `HAS_INTERACTIVE_QC`, `QC_var`, `remove_var`, `VARS_TO_QC`,
+    `QC_SUFFIX`.
+- **S4 — Sweep parameters** (used by `05_sweep_pass2.jl`): the
+  `SWEEP_*` / `INFER_*` grids, `NMD_TARGET`, `SECONDARY_METRIC`.
+- **S5 — QC output path** (`QC_PATH`, used by `06_qc.jl`).
+- **S6 — Hypertuning parameters** (used by `run_workflow.jl`): the
+  `HYPERTUNE_*` grids.
+
+The bottom of the file (do not edit) assembles `config_kwargs`, calls
+`make_config(...)`, and defines `configure_pass!(config, pass)`, which applies
+the relevant `PASS_CONFIG` entry (conv variables, selected features, masked-conv
+settings) to `config` before each pass operation.
+
+`kitchen_sink_config.jl` is a drop-in replacement showing non-trivial settings;
+its `configure_pass!` omits the masked-conv block and it has no S6 section.
+
+## Per-pass configuration
+
+`PASS_CONFIG` is a `Dict` mapping pass number → a NamedTuple of overrides. Any
+pass without an entry falls back to the base `conv_variables` with all features
+and no masked convolutions. Pass 2+ typically appends `"met_prob_pass_1"` as a
+predictor and may add an experimental masked-conv block. Set a pass's
+`selected_features` after running importance for that pass.
+
+## `run_workflow.jl` orchestrator
+
+`run_workflow.jl` runs stages in **file order, top to bottom**, each guarded by
+a boolean flag (all default `false`). Set the flags you want at the top of the
+file and run it once. Selectors `MASK_PASS` (default `1`) and `TRAIN_PASS`
+(default `2`) target the pass-specific stages.
+
+High-level phase flags:
+
+- `RUN_SPLIT_DATA` — one-time data split (run before anything else).
+- `RUN_FULL_TRAINING` — train → evaluate → importance, all passes.
+- `RUN_FULL_RETRAIN` — retrain with `selected_features` → evaluate.
+- `USE_PRECOMPUTED_FEATURES` — skip feature calculation, use saved HDF5.
+- `RUN_VALIDATION` — also evaluate on the validation set.
+
+Incremental / fine-grained flags (run in this order):
+
+- `RUN_CALCULATE_FEATURES` — calculate and save features, no training.
+- `RUN_TRAINING` — train all passes from scratch.
+- `RUN_EVALUATION` — evaluate on the testing set.
+- `SKIP_EXISTING_MET_PROBS` — reuse `met_prob_pass_N` already in the CfRadials.
+- `RUN_IMPORTANCE` — compute feature importance for `TRAIN_PASS`.
+- `RUN_RETRAIN` — retrain `TRAIN_PASS` with pruned features.
+- `RUN_RETRAIN_EVALUATION` — evaluate the retrained model.
+- `RUN_HISTOGRAM` — show the met-prob distribution for `MASK_PASS`.
+- `RUN_GENERATE_MASKS` — (re)generate met-prob/masks from `MASK_PASS`.
+- `RUN_TRAIN_NEXT_PASS` — train `TRAIN_PASS` using existing prior-pass masks.
+- `RUN_PASS2_SWEEP` — sweep Pass 2 met-prob thresholds.
+- `RUN_HYPERTUNING` — sweep `n_trees` / `max_depth`, evaluate AUC on testing.
+- `RUN_QC` — apply QC and write corrected fields.
+
+(Re-read `run_workflow.jl` for the authoritative, current stage list — the
+flags above are stable but the file evolves; reason about flags, not line
+numbers.)
+
+## Config auto-persistence
+
+`run_workflow.jl` calls [`save_config`](@ref) to write
+`model_config_<EXPERIMENT_NAME>.jld2` at the start and end of a run. Inference
+and operational drivers can then reload the exact trained configuration without
+re-running the workflow:
+
+```julia
+config = load_config("model_config_aft_training.jld2")
+```
+
+This is the bridge to the operational entry points — see
+[Choosing a QC Entry Point](entrypoints.md).

--- a/src/Ronin.jl
+++ b/src/Ronin.jl
@@ -2512,6 +2512,20 @@ module Ronin
                 printstyled("  Pass $(i) config: $(length(config.conv_variables)) conv_variables, " *
                             "$(isempty(config.selected_features) ? "all" : "$(length(config.selected_features))") features$(masked_info)\n",
                             color=:cyan)
+
+                ## One-time, training-only note: which masked-conv (type@size)
+                ## combinations are skipped by design. Reported here (not per
+                ## scan in build_filtered_kernel_bank) so operational QC runs
+                ## stay quiet; it is fully determined by config, not data.
+                if !isempty(config.masked_conv_variables)
+                    skipped = masked_conv_skipped_combos(config.masked_conv_kernel_types,
+                                                         config.masked_conv_kernel_sizes)
+                    if !isempty(skipped)
+                        combo_str = join(["$(t)@$(k)x$(k)" for (t, k) in skipped], ", ")
+                        printstyled("    Note: size-restricted masked-conv kernels not built by design: " *
+                                    "$(combo_str). Expected — not an error.\n", color=:light_black)
+                    end
+                end
             end
 
             out = config.feature_output_paths[i]

--- a/src/Ronin.jl
+++ b/src/Ronin.jl
@@ -126,6 +126,37 @@ module Ronin
         end
     end
 
+    ## Internal: the number of feature columns a trained model expects.
+    ## A model trained on a `selected_features` subset expects that many columns;
+    ## otherwise it expects the full saved `feature_names` width. Returns 0 when
+    ## neither is known (legacy save_object models) so callers skip the check.
+    function _expected_feature_width(selected_features, feature_names)
+        !isempty(selected_features) && return length(selected_features)
+        !isempty(feature_names) && return length(feature_names)
+        return 0
+    end
+
+    ## Internal: fail fast with an actionable message when the convolution
+    ## feature matrix produced at inference is not the width the model was
+    ## trained on. The common cause is a missing prior-pass field
+    ## (e.g. met_prob_pass_<n>) which makes the masked-convolution block get
+    ## silently dropped, yielding a too-narrow X and an opaque BoundsError
+    ## deep inside the random forest.
+    function _check_feature_width(X, selected_features, feature_names, model_path, pass_i)
+        expected = _expected_feature_width(selected_features, feature_names)
+        expected == 0 && return
+        got = size(X, 2)
+        if got != expected
+            error("Feature width mismatch for pass $(pass_i) " *
+                  "(model $(basename(String(model_path)))): model expects " *
+                  "$(expected) features but $(got) were produced. This usually " *
+                  "means a required prior-pass field (e.g. met_prob_pass_<n>) is " *
+                  "absent from the CfRadial, so masked-convolution features were " *
+                  "silently dropped. Ensure earlier passes ran and wrote their " *
+                  "met_prob_pass_<n> fields before this pass.")
+        end
+    end
+
     """
         inspect_model_configuration(path::String; io::IO=stdout)
 
@@ -4214,6 +4245,7 @@ module Ronin
         model_selected_features = Vector{Vector{Int}}()
 
         model_conv_variables = Vector{Vector{String}}()
+        model_feature_names = Vector{Vector{String}}()
         model_masked_conv_variables = Vector{Vector{String}}()
         model_masked_conv_kernel_types = Vector{Vector{String}}()
         model_masked_conv_kernel_sizes = Vector{Vector{Int}}()
@@ -4223,6 +4255,7 @@ module Ronin
             md = load_model_with_metadata(path, config.task_mode)
             push!(models, md.model)
             push!(model_selected_features, md.selected_features)
+            push!(model_feature_names, md.feature_names)
             push!(model_conv_variables, md.conv_variables)
             push!(model_masked_conv_variables, md.masked_conv_variables)
             push!(model_masked_conv_kernel_types, md.masked_conv_kernel_types)
@@ -4399,6 +4432,7 @@ module Ronin
                     result = process_single_file_conv(f, config_pred, kernel_bank;
                                                       feature_mask=feature_mask, mask_features=QC_mask)
                     X, Y, indexer = result[1], result[2], result[3]
+                    _check_feature_width(X, model_selected_features[i], model_feature_names[i], model_path, i)
                 else
                     currt = config.task_paths[i]
                     cw = config.task_weights[i]
@@ -5245,6 +5279,7 @@ module Ronin
         ## Same pattern as composite_prediction at :4209-4219. In hand-tuned mode the
         ## returned vectors are empty defaults and aren't used.
         model_selected_features = Vector{Vector{Int}}()
+        model_feature_names = Vector{Vector{String}}()
         model_conv_variables = Vector{Vector{String}}()
         model_masked_conv_variables = Vector{Vector{String}}()
         model_masked_conv_kernel_types = Vector{Vector{String}}()
@@ -5254,6 +5289,7 @@ module Ronin
         for path in config.model_output_paths
             md = load_model_with_metadata(path, config.task_mode)
             push!(model_selected_features, md.selected_features)
+            push!(model_feature_names, md.feature_names)
             push!(model_conv_variables, md.conv_variables)
             push!(model_masked_conv_variables, md.masked_conv_variables)
             push!(model_masked_conv_kernel_types, md.masked_conv_kernel_types)
@@ -5338,6 +5374,7 @@ module Ronin
                         result = process_single_file_conv(f, config_pred, kernel_bank;
                                                           feature_mask=feature_mask, mask_features=QC_mask)
                         X, Y, indexer = result[1], result[2], result[3]
+                        _check_feature_width(X, model_selected_features[i], model_feature_names[i], model_path, i)
                     else
                         currt = config.task_paths[i]
                         cw = config.task_weights[i]
@@ -5354,6 +5391,7 @@ module Ronin
 
                         curr_model = models[i]
                         curr_proba = config.met_probs[i]
+                        met_prob_name = "met_prob_pass_$(i)"
                         ###Here's where we need to modify. The ONLY gates that will go on to the next pass
                         ### will be the ones between the thresholds, (inclusive on both ends)
 
@@ -5399,8 +5437,20 @@ module Ronin
                         close(f)
                         ###Probably need to remove this for speed purposes... keep it in memory,
                         ###clear it for the next scan. Just pass it to QC_mask
-                        ###If this wasn't the last pass, need to write a mask for the gates to be predicted upon in the next iteration
+                        ###If this wasn't the last pass, write met_prob and mask for the next pass.
+                        ###The met_prob_pass_<i> write-back is required: subsequent passes
+                        ###(e.g. fore_mask Pass 2) consume met_prob_pass_<i> both as a plain
+                        ###conv variable and as the masked-conv met_prob field. Without it the
+                        ###masked-conv block is silently dropped, producing a too-narrow feature
+                        ###matrix and a BoundsError deep in the RF. Mirrors composite_prediction.
                         if i < config.num_models
+                            met_prob_field = Matrix{Union{Missing, Float32}}(missings(scan_dims))[:]
+                            met_prob_field[indexer] .= met_probs
+                            met_prob_field = reshape(met_prob_field, scan_dims)
+                            write_field(file, met_prob_name, met_prob_field,
+                                attribs=Dict("Units" => "Probability", "Description" => "Meteorological probability from pass $(i)"),
+                                fillval=config.FILL_VAL, verbose=false)
+
                             gates_of_interest = (met_probs .>= nmd_threshold) .& (met_probs .<= met_threshold)
                             new_mask = Matrix{Union{Missing, Float32}}(missings(scan_dims))[:]
                             ###If there are no gates of interest, write out the mask as ALL MISSINGS
@@ -5413,6 +5463,17 @@ module Ronin
                             new_mask = reshape(new_mask, scan_dims)
                             write_field(file, config.mask_names[i+1], new_mask,  attribs=Dict("Units" => "Bool", "Description" => "Gates between met prob thresholds"), fillval=config.FILL_VAL)
                          end
+
+                        ###Save met_prob for the final pass too, so threshold sweeps /
+                        ###downstream tooling can read it back without recomputation.
+                        if i == config.num_models
+                            met_prob_field = Matrix{Union{Missing, Float32}}(missings(scan_dims))[:]
+                            met_prob_field[indexer] .= met_probs
+                            met_prob_field = reshape(met_prob_field, scan_dims)
+                            write_field(file, met_prob_name, met_prob_field,
+                                attribs=Dict("Units" => "Probability", "Description" => "Meteorological probability from pass $(i)"),
+                                fillval=config.FILL_VAL, verbose=false)
+                        end
                     else
                         ###If the sum of the indexer is zero, we're done. There's nothing to predict upon.
                         ###This will only happen on the first pass of the model, so we won't have to worry about actually making a prediction

--- a/src/Ronin.jl
+++ b/src/Ronin.jl
@@ -2644,6 +2644,12 @@ module Ronin
                     paths = [file_path]
                 end
 
+                ## Load model metadata once (only meaningful in convolution mode).
+                ## Hand-tuned mode leaves `md` as `nothing`; downstream code must guard.
+                md = config.task_mode == "convolution" ?
+                    load_model_with_metadata(model_path, config.task_mode) :
+                    nothing
+
                 for path in paths
 
                     dims = Dataset(path) do f
@@ -2651,8 +2657,6 @@ module Ronin
                     end
 
                     if config.task_mode == "convolution"
-                        # Load metadata from model JLD2 to match what the model expects
-                        md = load_model_with_metadata(model_path, config.task_mode)
                         config_single = deepcopy(config)
                         config_single.input_path = path
                         config_single.write_out = false
@@ -2680,7 +2684,11 @@ module Ronin
                                             write_out = false, QC_mask = QC_mask, mask_name = mask_name, weight_matrixes=cw)
                     end
 
-                    printstyled("  Prediction: X size=$(size(X)), model_selected_features=$(isempty(md.selected_features) ? "none" : "$(length(md.selected_features)) indices")\n", color=:cyan)
+                    if md !== nothing
+                        printstyled("  Prediction: X size=$(size(X)), model_selected_features=$(isempty(md.selected_features) ? "none" : "$(length(md.selected_features)) indices")\n", color=:cyan)
+                    else
+                        printstyled("  Prediction: X size=$(size(X))\n", color=:cyan)
+                    end
                     met_probs = DecisionTree.predict_proba(curr_model, X)
                     if size(met_probs)[2] < 2
                         throw(DomainError(1, "ERROR: ONLY ONE CLASS IN INPUT DATASET"))

--- a/src/Ronin.jl
+++ b/src/Ronin.jl
@@ -18,12 +18,12 @@ module Ronin
     using DataStructures
 
 
-    export get_NCP, airborne_ht, prob_groundgate
+    export airborne_ht, prob_groundgate
     export calc_avg, calc_std, calc_iso, process_single_file
     export parse_directory, get_num_tasks, get_task_params, remove_validation
     export calculate_features, calculate_features_conv
     export split_training_testing!, split_training_testing_validation!
-    export QC_scan, get_QC_mask
+    export QC_scan
     export evaluate_model, get_feature_importance, train_model
     export train_multi_model, train_single_pass, regenerate_masks, ModelConfig, make_config, composite_prediction, get_contingency, compute_balanced_class_weights
     export write_field, characterize_misclassified_gates, composite_QC
@@ -344,8 +344,20 @@ module Ronin
     ```julia
     task_mode::String
     ```
-    Whether to obtain feature tasks from a set of input files or user specified vector of strings. Planned to be implemented in a future release.
-    For now, codebase behavior is agnostic to its value.
+    Selects the feature-engineering regime. Codebase behavior is **not** agnostic
+    to this value — it branches across training, prediction, QC, and mask
+    generation:
+
+    - `task_mode == "convolution"` — convolution feature mode. Features are
+      derived from a kernel bank applied to `conv_variables` (plus appended
+      AHT/ELV/RNG/NRG scalars); see the Convolution Feature Mode documentation.
+      `run_hypertuning` requires this mode.
+    - `task_mode == ""` (or any value other than `"convolution"`) — legacy
+      hand-tuned predictor mode. Features come from the `task_paths` /
+      `task_weights` predictor specification (STD/ISO/AVG/RNG/NRG/PGG/AHT); see
+      the Legacy Hand-Tuned Mode documentation.
+
+    `regenerate_masks` is the only mode-agnostic pass utility.
 
     ```julia
     file_preprocessed::Vector{Bool}
@@ -1527,6 +1539,34 @@ module Ronin
                     n_trees=n_trees, max_depth=max_depth, class_weights=class_weights)
     end
 
+    """
+        train_model(X::Matrix, Y::Union{Matrix, Vector}, model_location::String;
+                     verify=false, verify_out="model_verification.h5",
+                     n_trees=21, max_depth=14,
+                     class_weights=Float32[1., 2.], max_threads=Threads.nthreads())
+
+    In-memory overload of [`train_model`](@ref): fit a `DecisionTree`
+    `RandomForestClassifier` directly on a feature matrix `X` and target vector
+    `Y` instead of reading them from an HDF5 file.
+
+    # Arguments
+    - `X`: feature matrix (rows = gates/samples, columns = features).
+    - `Y`: target labels (`1`/`true` = meteorological, `0`/`false` = non-met),
+      reshaped to a vector internally.
+    - `model_location`: path the fitted model is written to via `save_object`.
+
+    # Keywords
+    - `n_trees`, `max_depth`: random-forest hyperparameters.
+    - `class_weights`: per-sample weight vector; must match `length(Y)` or it is
+      ignored (with a warning) and uniform weights are used.
+    - `verify` / `verify_out`: when `verify`, write predicted vs. true labels to
+      the `verify_out` HDF5 file.
+    - `max_threads`: cap on fitting threads (defaults to all available).
+
+    Prints training accuracy and timing. The file-path method
+    `train_model(input_h5, model_location; ...)` simply loads `X`/`Y` (with
+    optional `row_subset`/`col_subset`) and delegates here.
+    """
     function train_model(X::Matrix, Y::Union{Matrix, Vector}, model_location::String;
                         verify::Bool=false, verify_out::String="model_verification.h5",
                         n_trees::Int = 21, max_depth::Int=14, class_weights::Vector{Float32} = Vector{Float32}([1.f0,2.f0]),
@@ -1825,6 +1865,39 @@ module Ronin
 
 
 
+    """
+        split_training_testing_validation!(DIR_PATHS::Vector{String},
+                                            TRAINING_PATH::String,
+                                            TESTING_PATH::String,
+                                            VALIDATION_PATH::String)
+
+    Split a directory or set of directories of cfradial files into **training,
+    testing, and held-out validation** sets, following the methodology of
+    DesRosiers and Bell 2023. This is the three-way analogue of
+    [`split_training_testing!`](@ref): it additionally carves out a validation
+    partition for unbiased final evaluation.
+
+    The default split is **72% training / 20% testing / 8% validation**. As with
+    the two-way split, this function assumes input directories contain only
+    cfradial files following standard naming conventions (thus implicitly
+    chronologically ordered), divides each case into several sections to limit
+    temporal autocorrelation while maximizing variance, and **softlinks** the
+    files into the destination directories.
+
+    An important note: always use absolute paths — relative paths break the
+    symlinks.
+
+    # Required Arguments
+    - `DIR_PATHS::Vector{String}`: directories of cfradials to split. Each
+      directory is treated as a distinct case.
+    - `TRAINING_PATH::String`: directory to softlink training files into.
+    - `TESTING_PATH::String`: directory to softlink testing files into.
+    - `VALIDATION_PATH::String`: directory to softlink the held-out validation
+      files into.
+
+    The destination directories are removed and recreated, so any existing
+    contents are discarded.
+    """
     function split_training_testing_validation!(DIR_PATHS::Vector{String}, TRAINING_PATH::String, TESTING_PATH::String, VALIDATION_PATH::String)
 
         ###TODO  - make sure to ignore .tmp_hawkedit files OTHERWISE WON'T WORK AS EXPECTED
@@ -4710,9 +4783,7 @@ module Ronin
         * `filepath::String` Name of netCDF file to write data to
         * `fieldname::String` What to call the data in the netCDF
         * `NEW_FIELD` Data dimensioned by `dim_names` to write to netCDF
-
     """
-
     function write_field(filepath::String, fieldname::String, NEW_FIELD; overwrite::Bool = true,
                 attribs::Dict = Dict(), dim_names::Tuple=("range", "time"), verbose::Bool=true, fillval::T = FILL_VAL) where T <: Real
 

--- a/src/Ronin.jl
+++ b/src/Ronin.jl
@@ -4051,8 +4051,13 @@ module Ronin
     """
     function QC_scan(config::ModelConfig, filepath::String, predictions::Vector{Bool}, init_idxer::Vector{Bool})
 
-        @assert (length(config.model_output_paths) == length(config.feature_output_paths)
-                 == length(config.met_probs) == length(config.task_paths) == length(config.task_weights) == length(config.mask_names))
+        if config.task_mode != "convolution"
+            @assert (length(config.model_output_paths) == length(config.feature_output_paths)
+                     == length(config.met_probs) == length(config.task_paths) == length(config.task_weights) == length(config.mask_names))
+        else
+            @assert (length(config.model_output_paths) == length(config.feature_output_paths)
+                     == length(config.met_probs) == length(config.mask_names))
+        end
 
         starttime = time()
 
@@ -4865,9 +4870,12 @@ module Ronin
         ###Returns precision, recall, f1, n true_postives, n false_positives, n true_negatives, n false_negatives
         scores = evaluate_model(Vector{Bool}(predictions), Vector{Bool}(targets))
 
+        task_descriptor = config.task_mode == "convolution" ?
+            [config.conv_variables] : [config.task_paths]
+
         retval = DataFrame(
                                 met_probs = [config.met_probs],
-                                task_paths = [config.task_paths],
+                                task_paths = task_descriptor,
                                 class_weights = [config.class_weights],
                                 n_trees = [config.n_trees],
                                 max_depth = [config.max_depth],
@@ -4900,21 +4908,34 @@ module Ronin
                 ###Otherwise, we need to mask out the features we want to apply the model to on the next pass
         @assert curr_model_num <= config.num_models
 
+        is_conv = config.task_mode == "convolution"
+
         ###If this is the 0th, we're just constructing the features for the first pass and don't need to do much other work
         ###This is basically useful for when we don't have a trained model and want to just get the initial set of features
         if curr_model_num > 0
             curr_model = load_model(config.model_output_paths[curr_model_num], config.task_mode)
             curr_metprobs = config.met_probs[curr_model_num]
-            curr_tasks = config.task_paths[curr_model_num]
-            curr_weights = config.task_weights[curr_model_num]
             curr_out = config.feature_output_paths[curr_model_num]
-            output_cols = get_num_tasks(curr_tasks)
+            curr_md = is_conv ? load_model_with_metadata(config.model_output_paths[curr_model_num], config.task_mode) : nothing
         else
             curr_model = ""
             curr_metprobs = ""
-            curr_tasks = config.task_paths[begin]
-            curr_weights = config.task_weights[begin]
             curr_out = config.feature_output_paths[begin]
+            curr_md = nothing
+        end
+
+        if is_conv
+            curr_tasks = String[]
+            curr_weights = nothing
+            output_cols = 0  # resolved per-file below
+        else
+            if curr_model_num > 0
+                curr_tasks = config.task_paths[curr_model_num]
+                curr_weights = config.task_weights[curr_model_num]
+            else
+                curr_tasks = config.task_paths[begin]
+                curr_weights = config.task_weights[begin]
+            end
             output_cols = get_num_tasks(curr_tasks)
         end
 
@@ -4939,9 +4960,10 @@ module Ronin
 
 
 
-        newX = X = Matrix{Float32}(undef,0,output_cols)
-        newY = Y = Matrix{Int64}(undef, 0,1)
-        idxs = Vector{}(undef,0)
+        X = is_conv ? Matrix{Float32}(undef, 0, 0) : Matrix{Float32}(undef, 0, output_cols)
+        Y = Matrix{Int64}(undef, 0, 1)
+        idxs = Vector{}(undef, 0)
+        all_feature_names = String[]
 
         for path in paths
 
@@ -4949,13 +4971,58 @@ module Ronin
                 (f.dim["range"], f.dim["time"])
             end
 
-            ###NEED to update this if it's beyond two pass so we can pass it the correct mask
-            newX, newY, curr_idx = calculate_features(path, curr_tasks, curr_out, true;
-                                verbose = config.verbose,
-                                REMOVE_LOW_SIG_QUALITY = config.REMOVE_LOW_SIG_QUALITY, SIG_QUALITY_THRESHOLD = config.SIG_QUALITY_THRESHOLD, SIG_QUALITY_VAR = config.SIG_QUALITY_VAR,
-                                REMOVE_HIGH_PGG=config.REMOVE_HIGH_PGG, PGG_THRESHOLD = config.PGG_THRESHOLD, QC_variable = config.QC_var,
-                                remove_variable = config.remove_var, replace_missing = config.replace_missing, return_idxer=true,
-                                write_out = false, QC_mask = QC_mask, mask_name = mask_name, weight_matrixes=curr_weights)
+            if is_conv
+                config_single = deepcopy(config)
+                config_single.input_path = path
+                config_single.write_out = false
+                config_single.verbose = false
+                if curr_md !== nothing
+                    config_single.selected_features = curr_md.selected_features
+                    if !isempty(curr_md.conv_variables)
+                        config_single.conv_variables = curr_md.conv_variables
+                    end
+                    config_single.masked_conv_variables = curr_md.masked_conv_variables
+                    config_single.masked_conv_kernel_types = curr_md.masked_conv_kernel_types
+                    config_single.masked_conv_kernel_sizes = curr_md.masked_conv_kernel_sizes
+                    config_single.masked_conv_threshold = curr_md.masked_conv_threshold
+                    config_single.masked_conv_met_prob_field = curr_md.masked_conv_met_prob_field
+                end
+                kernel_bank = build_kernel_bank(config_single.conv_kernel_sizes)
+                masked_conv_kb = if !isempty(config_single.masked_conv_variables)
+                    build_filtered_kernel_bank(config_single.masked_conv_kernel_types, config_single.masked_conv_kernel_sizes)
+                else
+                    ConvolutionKernel[]
+                end
+
+                cfrad = Dataset(path)
+                try
+                    fm = (QC_mask && mask_name != "") ?
+                        Matrix{Bool}(.!map(ismissing, cfrad[mask_name][:, :])) :
+                        trues(dims)
+                    result = process_single_file_conv(cfrad, config_single, kernel_bank;
+                                                      feature_mask=fm, mask_features=QC_mask)
+                    newX = result[1]
+                    newY = result[2]
+                    curr_idx_flat = result[3]
+                    feature_names = result[4]
+                    if isempty(all_feature_names)
+                        all_feature_names = feature_names
+                    end
+                    curr_idx = (reshape(curr_idx_flat, dims),)
+                    close(cfrad)
+                catch e
+                    close(cfrad)
+                    rethrow(e)
+                end
+            else
+                ###NEED to update this if it's beyond two pass so we can pass it the correct mask
+                newX, newY, curr_idx = calculate_features(path, curr_tasks, curr_out, true;
+                                    verbose = config.verbose,
+                                    REMOVE_LOW_SIG_QUALITY = config.REMOVE_LOW_SIG_QUALITY, SIG_QUALITY_THRESHOLD = config.SIG_QUALITY_THRESHOLD, SIG_QUALITY_VAR = config.SIG_QUALITY_VAR,
+                                    REMOVE_HIGH_PGG=config.REMOVE_HIGH_PGG, PGG_THRESHOLD = config.PGG_THRESHOLD, QC_variable = config.QC_var,
+                                    remove_variable = config.remove_var, replace_missing = config.replace_missing, return_idxer=true,
+                                    write_out = false, QC_mask = QC_mask, mask_name = mask_name, weight_matrixes=curr_weights)
+            end
 
             if (curr_model_num < config.num_models) && (curr_model_num > 0)
 
@@ -4978,8 +5045,13 @@ module Ronin
                 write_field(path, config.mask_names[curr_model_num+1], new_mask, attribs=Dict("Units" => "Bool", "Description" => "Gates between met prob thresholds"))
             end
 
+            if is_conv && size(X, 2) == 0 && size(newX, 2) > 0
+                X = Matrix{Float32}(undef, 0, size(newX, 2))
+            end
             X = vcat(X, newX)::Matrix{Float32}
-            Y = vcat(Y, newY)::Matrix{Int64}
+            if newY !== false
+                Y = vcat(Y, newY)::Matrix{Int64}
+            end
 
         end
 
@@ -4994,7 +5066,12 @@ module Ronin
             fid = h5open(curr_out, "w")
 
             ###Add information to output h5 file
-            attributes(fid)["Parameters"] = get_task_params(curr_tasks)
+            if is_conv
+                params = isempty(config.selected_features) ? all_feature_names : all_feature_names[config.selected_features]
+                attributes(fid)["Parameters"] = params
+            else
+                attributes(fid)["Parameters"] = get_task_params(curr_tasks)
+            end
             attributes(fid)["MISSING_FILL_VALUE"] = config.FILL_VAL
             println()
             println("WRITING DATA TO FILE OF SHAPE $(size(X))")
@@ -5134,11 +5211,54 @@ module Ronin
 
 
     """
-    Streaming flavor of composite prediction used to
-    QC sweeps in a realtime setup.
+        composite_QC(config::ModelConfig, files::Vector{String},
+                     models::Vector{Ronin.DecisionTree.RandomForestClassifier})
+        composite_QC(config::ModelConfig, files::Vector{String})
+
+    Streaming flavor of `composite_prediction` used to QC sweeps in a realtime
+    setup. Operates on an explicit list of CfRadial files (not `config.input_path`),
+    runs each pass of the cascade in turn, and writes `*<QC_SUFFIX>` fields back
+    into each file via `QC_scan`.
+
+    Supports both `task_mode = ""` (hand-tuned `task_paths`) and
+    `task_mode = "convolution"`. In convolution mode, per-model metadata
+    (`selected_features`, `conv_variables`, `masked_conv_*`) is loaded internally
+    from each `model_output_paths` JLD2 file; the supplied `models` vector is
+    used only for `predict_proba`.
+
+    The 2-arg form omits `models` and loads the random forests internally as
+    well — convenient for operational pipelines where the snippet is just
+    `composite_QC(load_config(path), files)`.
     """
     function composite_QC(config::ModelConfig,
                                         files::Vector{String}, models::Vector{Ronin.DecisionTree.RandomForestClassifier})
+
+        ## Load per-model metadata once (selected_features, conv_variables, masked_conv_*).
+        ## Same pattern as composite_prediction at :4209-4219. In hand-tuned mode the
+        ## returned vectors are empty defaults and aren't used.
+        model_selected_features = Vector{Vector{Int}}()
+        model_conv_variables = Vector{Vector{String}}()
+        model_masked_conv_variables = Vector{Vector{String}}()
+        model_masked_conv_kernel_types = Vector{Vector{String}}()
+        model_masked_conv_kernel_sizes = Vector{Vector{Int}}()
+        model_masked_conv_thresholds = Vector{Float32}()
+        model_masked_conv_met_prob_fields = Vector{String}()
+        for path in config.model_output_paths
+            md = load_model_with_metadata(path, config.task_mode)
+            push!(model_selected_features, md.selected_features)
+            push!(model_conv_variables, md.conv_variables)
+            push!(model_masked_conv_variables, md.masked_conv_variables)
+            push!(model_masked_conv_kernel_types, md.masked_conv_kernel_types)
+            push!(model_masked_conv_kernel_sizes, md.masked_conv_kernel_sizes)
+            push!(model_masked_conv_thresholds, md.masked_conv_threshold)
+            push!(model_masked_conv_met_prob_fields, md.masked_conv_met_prob_field)
+        end
+
+        ## Build the kernel bank once for the whole run (convolution mode only;
+        ## cheap to construct unconditionally).
+        kernel_bank = config.task_mode == "convolution" ?
+            build_kernel_bank(config.conv_kernel_sizes) :
+            ConvolutionKernel[]
 
         for file in files
 
@@ -5166,9 +5286,6 @@ module Ronin
                 QC_mask = config.QC_mask
                 for (i, model_path) in enumerate(config.model_output_paths)
 
-
-                    currt = config.task_paths[i]
-                    cw = config.task_weights[i]
                     ###REFACTOR NOTES: I THINK PROCESS_SINGLE_FILE CLOSES THE FILE SO WILL NEED TO CHANGE THAT
                     ###TO MOVE OUTSIDE LOOP
                     ###We don't need to write these out, just use them briefly
@@ -5198,11 +5315,30 @@ module Ronin
 
                     ###Need to actually pass the QC mask
                     ###indexer will contain true where gates in the file both were NOT masked out AND met the basic QC thresholds
-                    X, Y, indexer = process_single_file(f, currt, HAS_INTERACTIVE_QC = ((! true) && config.HAS_INTERACTIVE_QC)
-                        , REMOVE_HIGH_PGG = config.REMOVE_HIGH_PGG, PGG_THRESHOLD = config.PGG_THRESHOLD,
-                        REMOVE_LOW_SIG_QUALITY = config.REMOVE_LOW_SIG_QUALITY, SIG_QUALITY_THRESHOLD = config.SIG_QUALITY_THRESHOLD, SIG_QUALITY_VAR = config.SIG_QUALITY_VAR,
-                        QC_variable = config.QC_var, replace_missing = config.replace_missing, remove_variable = config.remove_var,
-                        mask_features = QC_mask, feature_mask = feature_mask, weight_matrixes=cw)
+                    if config.task_mode == "convolution"
+                        config_pred = deepcopy(config)
+                        config_pred.HAS_INTERACTIVE_QC = false
+                        config_pred.selected_features = model_selected_features[i]
+                        if !isempty(model_conv_variables[i])
+                            config_pred.conv_variables = model_conv_variables[i]
+                        end
+                        config_pred.masked_conv_variables = model_masked_conv_variables[i]
+                        config_pred.masked_conv_kernel_types = model_masked_conv_kernel_types[i]
+                        config_pred.masked_conv_kernel_sizes = model_masked_conv_kernel_sizes[i]
+                        config_pred.masked_conv_threshold = model_masked_conv_thresholds[i]
+                        config_pred.masked_conv_met_prob_field = model_masked_conv_met_prob_fields[i]
+                        result = process_single_file_conv(f, config_pred, kernel_bank;
+                                                          feature_mask=feature_mask, mask_features=QC_mask)
+                        X, Y, indexer = result[1], result[2], result[3]
+                    else
+                        currt = config.task_paths[i]
+                        cw = config.task_weights[i]
+                        X, Y, indexer = process_single_file(f, currt, HAS_INTERACTIVE_QC = ((! true) && config.HAS_INTERACTIVE_QC)
+                            , REMOVE_HIGH_PGG = config.REMOVE_HIGH_PGG, PGG_THRESHOLD = config.PGG_THRESHOLD,
+                            REMOVE_LOW_SIG_QUALITY = config.REMOVE_LOW_SIG_QUALITY, SIG_QUALITY_THRESHOLD = config.SIG_QUALITY_THRESHOLD, SIG_QUALITY_VAR = config.SIG_QUALITY_VAR,
+                            QC_variable = config.QC_var, replace_missing = config.replace_missing, remove_variable = config.remove_var,
+                            mask_features = QC_mask, feature_mask = feature_mask, weight_matrixes=cw)
+                    end
                     final_idxer = indexer
 
                     ###If there are no gates that meet the basic QC thresholds now, we're once again done.
@@ -5284,7 +5420,22 @@ module Ronin
         end
     end
 
+    """
+        composite_QC(config::ModelConfig, files::Vector{String})
 
+    Convenience 2-arg method that loads the random forests from
+    `config.model_output_paths` internally and forwards to the 3-arg form.
+    Equivalent to:
+
+        models = [load_model(p, config.task_mode) for p in config.model_output_paths]
+        composite_QC(config, files, models)
+    """
+    function composite_QC(config::ModelConfig, files::Vector{String})
+        models = Ronin.DecisionTree.RandomForestClassifier[
+            load_model(p, config.task_mode) for p in config.model_output_paths
+        ]
+        composite_QC(config, files, models)
+    end
 
 
 end

--- a/src/Ronin.jl
+++ b/src/Ronin.jl
@@ -157,6 +157,65 @@ module Ronin
         end
     end
 
+    ## Classify a CfRadial file's on-disk layout. Ronin's feature path assumes
+    ## the flat CfRadial 1.x gridded layout: root-level `range`/`time` dims with
+    ## field variables shaped (range, time). Returns `(layout, scan_dims)`:
+    ##   :ok          — flat v1 gridded; scan_dims = (nrange, ntime)
+    ##   :cfradial2   — hierarchical v2 (sweep_*/ groups); scan_dims = (0, 0)
+    ##   :ragged      — contiguous ragged-array (n_points / ray_n_gates); (0, 0)
+    ##   :unsupported — root missing `range` or `time` for other reasons; (0, 0)
+    function _detect_cfrad_layout(f::NCDataset)
+        has_root_range = "range" in keys(f)
+        has_root_time  = "time"  in keys(f)
+        convs = try
+            lowercase(string(get(f.attrib, "Conventions", "")))
+        catch
+            ""
+        end
+        grp_names = try
+            collect(keys(f.group))
+        catch
+            String[]
+        end
+        has_sweep_group = any(g -> startswith(string(g), "sweep"), grp_names)
+        is_v2 = ("sweep_group_name" in keys(f)) || has_sweep_group ||
+                (occursin("2.0", convs) && occursin("cfradial", convs))
+        is_ragged = haskey(f.dim, "n_points") ||
+                    ("ray_n_gates" in keys(f)) ||
+                    ("ray_start_index" in keys(f))
+        if is_v2
+            return (:cfradial2, (0, 0))
+        elseif is_ragged
+            return (:ragged, (0, 0))
+        elseif !has_root_range || !has_root_time
+            return (:unsupported, (0, 0))
+        else
+            return (:ok, (dimsize(f["range"]).range, dimsize(f["time"]).time))
+        end
+    end
+
+    ## Emit a yellow WARNING describing why a file is being skipped by the
+    ## gridded QC / prediction path. No-op for `:ok`.
+    function _warn_unsupported_cfrad(layout::Symbol, file::AbstractString)
+        if layout == :cfradial2
+            printstyled("WARNING: Skipping CfRadial 2.0 (hierarchical sweep " *
+                        "groups), unsupported by the gridded path: $(file)\n" *
+                        "         Convert to CfRadial 1.x (e.g. RadxConvert " *
+                        "-cfradial1 -const_ngate) to process this file.\n",
+                        color=:yellow)
+        elseif layout == :ragged
+            printstyled("WARNING: Skipping ragged-array CfRadial (n_points " *
+                        "representation), unsupported by the gridded path: " *
+                        "$(file)\n         Convert to a gridded CfRadial " *
+                        "(e.g. RadxConvert -const_ngate) to process this file.\n",
+                        color=:yellow)
+        elseif layout == :unsupported
+            printstyled("WARNING: Skipping file with unsupported CfRadial " *
+                        "layout (no root `range`/`time` variable): $(file)\n",
+                        color=:yellow)
+        end
+    end
+
     """
         inspect_model_configuration(path::String; io::IO=stdout)
 
@@ -4374,27 +4433,18 @@ module Ronin
         ###Probably can section this off into a different function later since it's also reused in the streaming/realtime version
         for file in files
             curr_starttime = time()
-                ###Get dimensions, and detect the CfRadial contiguous ragged-array
-                ###representation (n_points / ray_start_index / ray_n_gates), which
-                ###Ronin's gridded (range × time) feature path cannot ingest.
-                ###Skip ragged files with a clear warning rather than crashing.
+                ###Classify the CfRadial layout and skip files the gridded
+                ###feature path cannot ingest (CfRadial 2.0 hierarchical sweep
+                ###groups, ragged n_points arrays, or root layouts missing
+                ###`range`/`time`).
 
-            is_ragged, scan_dims = redirect_stdout(devnull) do
-
+            layout, scan_dims = redirect_stdout(devnull) do
                 NCDataset(file) do f
-                    ragged = haskey(f.dim, "n_points") ||
-                             ("ray_n_gates" in keys(f)) ||
-                             ("ray_start_index" in keys(f))
-                    (ragged, (dimsize(f["range"]).range, dimsize(f["time"]).time))
+                    _detect_cfrad_layout(f)
                 end
             end
-
-            if is_ragged
-                printstyled("WARNING: Skipping ragged-array CfRadial (n_points " *
-                            "representation), unsupported by the gridded prediction " *
-                            "path: $(file)\n         Convert to a gridded CfRadial " *
-                            "(e.g. RadxConvert -const_ngate) to process this file.\n",
-                            color=:yellow)
+            if layout != :ok
+                _warn_unsupported_cfrad(layout, file)
                 continue
             end
 
@@ -5423,24 +5473,16 @@ module Ronin
                 if isdir(file)
                     continue
                 end
-                ###Get dimensions, and detect the CfRadial contiguous ragged-array
-                ###representation (n_points / ray_start_index / ray_n_gates), which
-                ###Ronin's gridded (range × time) feature path cannot ingest.
-                ###Skip ragged files with a clear warning rather than crashing the
-                ###whole volume/day chunk.
-                is_ragged, scan_dims = NCDataset(file) do f
-                    ragged = haskey(f.dim, "n_points") ||
-                             ("ray_n_gates" in keys(f)) ||
-                             ("ray_start_index" in keys(f))
-                    (ragged, (dimsize(f["range"]).range, dimsize(f["time"]).time))
+                ###Classify the CfRadial layout and skip files that the gridded
+                ###feature path cannot ingest (CfRadial 2.0 hierarchical sweep
+                ###groups, ragged n_points arrays, or root layouts missing
+                ###`range`/`time`). This keeps process_day_chunks alive on a
+                ###mixed-format batch instead of crashing the whole volume.
+                layout, scan_dims = NCDataset(file) do f
+                    _detect_cfrad_layout(f)
                 end
-
-                if is_ragged
-                    printstyled("WARNING: Skipping ragged-array CfRadial (n_points " *
-                                "representation), unsupported by the gridded QC path: " *
-                                "$(file)\n         Convert to a gridded CfRadial " *
-                                "(e.g. RadxConvert -const_ngate) to QC this file.\n",
-                                color=:yellow)
+                if layout != :ok
+                    _warn_unsupported_cfrad(layout, file)
                     continue
                 end
 

--- a/src/Ronin.jl
+++ b/src/Ronin.jl
@@ -70,31 +70,31 @@ module Ronin
         load_model(path::String, task_mode::String)
 
     Load a trained model from a JLD2 file, handling both storage formats:
-      - `save_object` format (plain model, no keys)
-      - `JLD2.jldsave` format (keyed: "model", "selected_features", etc.)
+      - `save_object` format (single key `"single_stored_object"`)
+      - `JLD2.jldsave` format (keyed: `"model"`, `"selected_features"`, etc.)
 
-    Returns the model object regardless of which format was used.
+    Returns the model object regardless of which format was used. The
+    `task_mode` argument is accepted for API compatibility but ignored;
+    layout is inferred from the file's keys.
     """
     function load_model(path::String, task_mode::String)
-        if task_mode == "convolution"
-            data = JLD2.load(path)
-            if data isa Dict && haskey(data, "model")
-                return data["model"]
-            elseif data isa Dict && haskey(data, "single_stored_object")
-                # Saved with save_object (wraps in "single_stored_object" key)
-                return data["single_stored_object"]
-            else
-                return data
-            end
+        data = JLD2.load(path)
+        if data isa Dict && haskey(data, "model")
+            return data["model"]
+        elseif data isa Dict && haskey(data, "single_stored_object")
+            return data["single_stored_object"]
         else
-            return load_object(path)
+            return data
         end
     end
 
     """
         load_model_with_metadata(path::String, task_mode::String)
 
-    Load a trained model and its metadata from a JLD2 file.
+    Load a trained model and its metadata from a JLD2 file. Accepts either
+    storage layout (single-key `save_object` or multi-key `JLD2.jldsave`).
+    `task_mode` is kept for API compatibility but is ignored; layout is
+    inferred from the file's keys.
 
     Returns a NamedTuple with fields:
       - `model`: the trained RF ensemble
@@ -104,49 +104,36 @@ module Ronin
       - `importances`: Vector{Float64} of feature importance scores (empty if not saved)
     """
     function load_model_with_metadata(path::String, task_mode::String)
-        if task_mode == "convolution"
-            data = JLD2.load(path)
-            if data isa Dict
-                model = if haskey(data, "model")
-                    data["model"]
-                elseif haskey(data, "single_stored_object")
-                    data["single_stored_object"]
-                else
-                    data
-                end
-                selected = get(data, "selected_features", Int[])
-                recommended = get(data, "recommended_features", Int[])
-                feat_names = get(data, "feature_names", String[])
-                imps = get(data, "importances", Float64[])
-                conv_vars = get(data, "conv_variables", String[])
-                masked_conv_vars = get(data, "masked_conv_variables", String[])
-                masked_conv_ktypes = get(data, "masked_conv_kernel_types", String[])
-                masked_conv_ksizes = get(data, "masked_conv_kernel_sizes", Int[])
-                masked_conv_thresh = get(data, "masked_conv_threshold", 0.1f0)
-                masked_conv_mpf = get(data, "masked_conv_met_prob_field", "")
-                return (model=model, selected_features=selected,
-                        recommended_features=recommended,
-                        feature_names=feat_names, importances=imps,
-                        conv_variables=conv_vars,
-                        masked_conv_variables=masked_conv_vars,
-                        masked_conv_kernel_types=masked_conv_ktypes,
-                        masked_conv_kernel_sizes=masked_conv_ksizes,
-                        masked_conv_threshold=masked_conv_thresh,
-                        masked_conv_met_prob_field=masked_conv_mpf)
+        data = JLD2.load(path)
+        if data isa Dict
+            model = if haskey(data, "model")
+                data["model"]
+            elseif haskey(data, "single_stored_object")
+                data["single_stored_object"]
             else
-                return (model=data, selected_features=Int[],
-                        recommended_features=Int[],
-                        feature_names=String[], importances=Float64[],
-                        conv_variables=String[],
-                        masked_conv_variables=String[],
-                        masked_conv_kernel_types=String[],
-                        masked_conv_kernel_sizes=Int[],
-                        masked_conv_threshold=0.1f0,
-                        masked_conv_met_prob_field="")
+                data
             end
+            selected = get(data, "selected_features", Int[])
+            recommended = get(data, "recommended_features", Int[])
+            feat_names = get(data, "feature_names", String[])
+            imps = get(data, "importances", Float64[])
+            conv_vars = get(data, "conv_variables", String[])
+            masked_conv_vars = get(data, "masked_conv_variables", String[])
+            masked_conv_ktypes = get(data, "masked_conv_kernel_types", String[])
+            masked_conv_ksizes = get(data, "masked_conv_kernel_sizes", Int[])
+            masked_conv_thresh = get(data, "masked_conv_threshold", 0.1f0)
+            masked_conv_mpf = get(data, "masked_conv_met_prob_field", "")
+            return (model=model, selected_features=selected,
+                    recommended_features=recommended,
+                    feature_names=feat_names, importances=imps,
+                    conv_variables=conv_vars,
+                    masked_conv_variables=masked_conv_vars,
+                    masked_conv_kernel_types=masked_conv_ktypes,
+                    masked_conv_kernel_sizes=masked_conv_ksizes,
+                    masked_conv_threshold=masked_conv_thresh,
+                    masked_conv_met_prob_field=masked_conv_mpf)
         else
-            model = load_object(path)
-            return (model=model, selected_features=Int[],
+            return (model=data, selected_features=Int[],
                     recommended_features=Int[],
                     feature_names=String[], importances=Float64[],
                     conv_variables=String[],

--- a/src/Ronin.jl
+++ b/src/Ronin.jl
@@ -227,15 +227,11 @@ module Ronin
     end
 
     ## Emit a yellow WARNING describing why a file is being skipped by the
-    ## gridded QC / prediction path. No-op for `:ok`.
+    ## driver paths. No-op for `:ok` and `:cfradial2` (CfRadial 2.0 is
+    ## processed natively via per-sweep iteration; only ragged-array layouts
+    ## and other unsupported root layouts are skipped).
     function _warn_unsupported_cfrad(layout::Symbol, file::AbstractString)
-        if layout == :cfradial2
-            printstyled("WARNING: Skipping CfRadial 2.0 (hierarchical sweep " *
-                        "groups), unsupported by the gridded path: $(file)\n" *
-                        "         Convert to CfRadial 1.x (e.g. RadxConvert " *
-                        "-cfradial1 -const_ngate) to process this file.\n",
-                        color=:yellow)
-        elseif layout == :ragged
+        if layout == :ragged
             printstyled("WARNING: Skipping ragged-array CfRadial (n_points " *
                         "representation), unsupported by the gridded path: " *
                         "$(file)\n         Convert to a gridded CfRadial " *
@@ -243,7 +239,8 @@ module Ronin
                         color=:yellow)
         elseif layout == :unsupported
             printstyled("WARNING: Skipping file with unsupported CfRadial " *
-                        "layout (no root `range`/`time` variable): $(file)\n",
+                        "layout (no root `range`/`time` variable and no " *
+                        "/sweep_NNNN groups): $(file)\n",
                         color=:yellow)
         end
     end
@@ -1584,46 +1581,52 @@ module Ronin
         starttime = time()
 
         for path in paths
-            cfrad = Dataset(path)
+            layout, _ = NCDataset(path) do f; _detect_cfrad_layout(f); end
+            if layout == :ragged || layout == :unsupported
+                _warn_unsupported_cfrad(layout, path)
+                continue
+            end
+
+            pathstarttime = time()
             try
-                pathstarttime = time()
-                dims = (cfrad.dim["range"], cfrad.dim["time"])
+                NCDataset(path) do f
+                    for sv in sweep_views(f)
+                        dims = (dim_size(sv, "range"), dim_size(sv, "time"))
 
-                fm = if QC_mask && mask_name != ""
-                    Matrix{Bool}(.!map(ismissing, cfrad[mask_name][:, :]))
-                else
-                    trues(dims)
+                        fm = if QC_mask && mask_name != ""
+                            Matrix{Bool}(.!map(ismissing, sv[mask_name][:, :]))
+                        else
+                            trues(dims)
+                        end
+
+                        result = process_single_file_conv(sv, config, kernel_bank;
+                                                           feature_mask=fm, mask_features=QC_mask)
+                        newX = result[1]
+                        newY = result[2]
+                        indexer = result[3]
+                        feature_names = result[4]
+
+                        if isempty(all_feature_names)
+                            all_feature_names = feature_names
+                        end
+
+                        X = vcat(X, newX)::Matrix{Float32}
+                        if newY !== false
+                            Y = vcat(Y, newY)::Matrix{Int64}
+                        end
+                        push!(idxs, reshape(indexer, dims))
+                    end
                 end
-
-                result = process_single_file_conv(cfrad, config, kernel_bank;
-                                                   feature_mask=fm, mask_features=QC_mask)
-                newX = result[1]
-                newY = result[2]
-                indexer = result[3]
-                feature_names = result[4]
-
-                if isempty(all_feature_names)
-                    all_feature_names = feature_names
-                end
-
-                close(cfrad)
 
                 if config.verbose
                     println("Processed $(path) in $(round(time() - pathstarttime, digits=2)) seconds [conv mode]")
                 end
-
-                X = vcat(X, newX)::Matrix{Float32}
-                if newY !== false
-                    Y = vcat(Y, newY)::Matrix{Int64}
-                end
-                push!(idxs, reshape(indexer, dims))
 
             catch e
                 if isa(e, DimensionMismatch)
                     printstyled(Base.stderr, "POSSIBLE ERRONEOUS CFRAD DIMENSIONS... SKIPPING $(path)\n"; color=:red)
                     continue
                 else
-                    close(cfrad)
                     throw(e)
                 end
             end
@@ -2953,74 +2956,99 @@ module Ronin
                     load_model_with_metadata(model_path, config.task_mode) :
                     nothing
 
+                kernel_bank_train = config.task_mode == "convolution" ?
+                    build_kernel_bank(config.conv_kernel_sizes) :
+                    ConvolutionKernel[]
+
                 for path in paths
 
-                    dims = Dataset(path) do f
-                        (f.dim["range"], f.dim["time"])
+                    layout, _ = NCDataset(path) do f; _detect_cfrad_layout(f); end
+                    if layout == :ragged || layout == :unsupported
+                        _warn_unsupported_cfrad(layout, path)
+                        continue
                     end
 
-                    if config.task_mode == "convolution"
-                        config_single = deepcopy(config)
-                        config_single.input_path = path
-                        config_single.write_out = false
-                        config_single.selected_features = md.selected_features
-                        if !isempty(md.conv_variables)
-                            config_single.conv_variables = md.conv_variables
+                    NCDataset(path, "a") do f
+                        for sv in sweep_views(f)
+                            dims = (dim_size(sv, "range"), dim_size(sv, "time"))
+
+                            if config.task_mode == "convolution"
+                                fm = (QC_mask && mask_name != "") ?
+                                    Matrix{Bool}(.!map(ismissing, sv[mask_name][:, :])) :
+                                    trues(dims)
+                                config_single = deepcopy(config)
+                                config_single.input_path = path
+                                config_single.write_out = false
+                                config_single.selected_features = md.selected_features
+                                if !isempty(md.conv_variables)
+                                    config_single.conv_variables = md.conv_variables
+                                end
+                                config_single.masked_conv_variables = md.masked_conv_variables
+                                config_single.masked_conv_kernel_types = md.masked_conv_kernel_types
+                                config_single.masked_conv_kernel_sizes = md.masked_conv_kernel_sizes
+                                config_single.masked_conv_threshold = md.masked_conv_threshold
+                                config_single.masked_conv_met_prob_field = md.masked_conv_met_prob_field
+                                result = process_single_file_conv(sv, config_single, kernel_bank_train;
+                                                                   feature_mask=fm, mask_features=QC_mask)
+                                X = result[1]
+                                indexer = result[3]
+                            else
+                                currt = config.task_paths[i]
+                                cw = config.task_weights[i]
+                                result = process_single_file(sv, currt;
+                                                              HAS_INTERACTIVE_QC = true,
+                                                              REMOVE_LOW_SIG_QUALITY = config.REMOVE_LOW_SIG_QUALITY,
+                                                              SIG_QUALITY_THRESHOLD = config.SIG_QUALITY_THRESHOLD,
+                                                              SIG_QUALITY_VAR = config.SIG_QUALITY_VAR,
+                                                              REMOVE_HIGH_PGG = config.REMOVE_HIGH_PGG,
+                                                              PGG_THRESHOLD = config.PGG_THRESHOLD,
+                                                              QC_variable = config.QC_var,
+                                                              remove_variable = config.remove_var,
+                                                              replace_missing = config.replace_missing,
+                                                              mask_features = QC_mask,
+                                                              feature_mask = QC_mask ? Matrix{Bool}(.!map(ismissing, sv[mask_name][:, :])) : [true true; false false],
+                                                              weight_matrixes = cw)
+                                X = result[1]
+                                indexer = result[3]
+                            end
+
+                            if md !== nothing
+                                printstyled("  Prediction: X size=$(size(X)), model_selected_features=$(isempty(md.selected_features) ? "none" : "$(length(md.selected_features)) indices")\n", color=:cyan)
+                            else
+                                printstyled("  Prediction: X size=$(size(X))\n", color=:cyan)
+                            end
+                            met_probs = DecisionTree.predict_proba(curr_model, X)
+                            if size(met_probs)[2] < 2
+                                throw(DomainError(1, "ERROR: ONLY ONE CLASS IN INPUT DATASET"))
+                            end
+                            met_probs = met_probs[:, 2]
+                            valid_idxs = (met_probs .>= minimum(curr_metprobs)) .& (met_probs .<= maximum(curr_metprobs))
+                            print("RESULTANT GATES: $(sum(valid_idxs))")
+
+                            ## Save met_prob predictions for all valid gates so subsequent passes
+                            ## can use them as predictors and masks can be regenerated with different
+                            ## thresholds without re-running the model
+                            met_prob_field = Matrix{Union{Missing, Float32}}(missings(dims))[:]
+                            met_prob_idxer = copy(indexer)
+                            met_prob_field[met_prob_idxer] .= Float32.(met_probs)
+                            met_prob_field = reshape(met_prob_field, dims)
+                            met_prob_name = "met_prob_pass_$(i)"
+                            _define_or_overwrite!(sv, met_prob_name, met_prob_field;
+                                attribs=Dict("Units" => "probability",
+                                             "Description" => "RF meteorological probability from pass $(i)"))
+
+                            ##Create mask field, fill it, and then write out
+                            new_mask = Matrix{Union{Missing, Float32}}(missings(dims))[:]
+
+                            idxer_flat = copy(indexer)
+                            idxer_flat[idxer_flat] .= Vector{Bool}(valid_idxs)
+                            new_mask[idxer_flat] .= 1.
+                            new_mask = reshape(new_mask, dims)
+
+                            _define_or_overwrite!(sv, config.mask_names[i+1], new_mask;
+                                attribs=Dict("Units" => "Bool", "Description" => "Gates between met prob thresholds"))
                         end
-                        config_single.masked_conv_variables = md.masked_conv_variables
-                        config_single.masked_conv_kernel_types = md.masked_conv_kernel_types
-                        config_single.masked_conv_kernel_sizes = md.masked_conv_kernel_sizes
-                        config_single.masked_conv_threshold = md.masked_conv_threshold
-                        config_single.masked_conv_met_prob_field = md.masked_conv_met_prob_field
-                        X, Y, idxer_list = calculate_features_conv(config_single, out;
-                                                                     QC_mask=QC_mask, mask_name=mask_name,
-                                                                     write_out=false, return_idxer=true)
-                        idxer = idxer_list
-                    else
-                        currt = config.task_paths[i]
-                        cw = config.task_weights[i]
-                        X, Y, idxer = calculate_features(path, currt, out, true;
-                                            verbose = config.verbose,
-                                            REMOVE_LOW_SIG_QUALITY = config.REMOVE_LOW_SIG_QUALITY, SIG_QUALITY_THRESHOLD = config.SIG_QUALITY_THRESHOLD, SIG_QUALITY_VAR=config.SIG_QUALITY_VAR,
-                                            REMOVE_HIGH_PGG=config.REMOVE_HIGH_PGG,PGG_THRESHOLD=config.PGG_THRESHOLD, QC_variable = config.QC_var,
-                                            remove_variable = config.remove_var, replace_missing = config.replace_missing, return_idxer=true,
-                                            write_out = false, QC_mask = QC_mask, mask_name = mask_name, weight_matrixes=cw)
                     end
-
-                    if md !== nothing
-                        printstyled("  Prediction: X size=$(size(X)), model_selected_features=$(isempty(md.selected_features) ? "none" : "$(length(md.selected_features)) indices")\n", color=:cyan)
-                    else
-                        printstyled("  Prediction: X size=$(size(X))\n", color=:cyan)
-                    end
-                    met_probs = DecisionTree.predict_proba(curr_model, X)
-                    if size(met_probs)[2] < 2
-                        throw(DomainError(1, "ERROR: ONLY ONE CLASS IN INPUT DATASET"))
-                    end
-                    met_probs = met_probs[:, 2]
-                    valid_idxs = (met_probs .>= minimum(curr_metprobs)) .& (met_probs .<= maximum(curr_metprobs))
-                    print("RESULTANT GATES: $(sum(valid_idxs))")
-
-                    ## Save met_prob predictions for all valid gates so subsequent passes
-                    ## can use them as predictors and masks can be regenerated with different
-                    ## thresholds without re-running the model
-                    met_prob_field = Matrix{Union{Missing, Float32}}(missings(dims))[:]
-                    met_prob_idxer = copy(idxer[1][:])
-                    met_prob_field[met_prob_idxer] .= Float32.(met_probs)
-                    met_prob_field = reshape(met_prob_field, dims)
-                    met_prob_name = "met_prob_pass_$(i)"
-                    write_field(path, met_prob_name, met_prob_field,
-                        attribs=Dict("Units" => "probability",
-                                     "Description" => "RF meteorological probability from pass $(i)"))
-
-                    ##Create mask field, fill it, and then write out
-                    new_mask = Matrix{Union{Missing, Float32}}(missings(dims))[:]
-
-                    idxer = idxer[1][:]
-                    idxer[idxer] .= Vector{Bool}(valid_idxs)
-                    new_mask[idxer] .= 1.
-                    new_mask = reshape(new_mask, dims)
-
-                    write_field(path, config.mask_names[i+1], new_mask, attribs=Dict("Units" => "Bool", "Description" => "Gates between met prob thresholds"))
 
                 end
             end
@@ -3050,30 +3078,37 @@ module Ronin
 
         paths = isdir(config.input_path) ? parse_directory(config.input_path) : [config.input_path]
         met_prob_name = "met_prob_pass_$(pass)"
+        n_sweeps_total = 0
 
         for path in paths
-            dims = Dataset(path) do f
-                (f.dim["range"], f.dim["time"])
+            layout, _ = NCDataset(path) do f; _detect_cfrad_layout(f); end
+            if layout == :ragged || layout == :unsupported
+                _warn_unsupported_cfrad(layout, path)
+                continue
             end
 
-            met_prob_field = Dataset(path) do f
-                f[met_prob_name][:, :]
-            end
+            NCDataset(path, "a") do f
+                for sv in sweep_views(f)
+                    dims = (dim_size(sv, "range"), dim_size(sv, "time"))
+                    met_prob_field = sv[met_prob_name][:, :]
 
-            new_mask = Matrix{Union{Missing, Float32}}(missings(dims))
-            for j in 1:dims[2], i in 1:dims[1]
-                v = met_prob_field[i, j]
-                if !ismissing(v) && v >= met_probs_threshold[1] && v <= met_probs_threshold[2]
-                    new_mask[i, j] = 1.0f0
+                    new_mask = Matrix{Union{Missing, Float32}}(missings(dims))
+                    for j in 1:dims[2], i in 1:dims[1]
+                        x = met_prob_field[i, j]
+                        if !ismissing(x) && x >= met_probs_threshold[1] && x <= met_probs_threshold[2]
+                            new_mask[i, j] = 1.0f0
+                        end
+                    end
+
+                    _define_or_overwrite!(sv, config.mask_names[pass + 1], new_mask;
+                        attribs=Dict("Units" => "Bool",
+                                     "Description" => "Gates between met prob thresholds"),
+                        verbose=false)
+                    n_sweeps_total += 1
                 end
             end
-
-            write_field(path, config.mask_names[pass + 1], new_mask,
-                attribs=Dict("Units" => "Bool",
-                             "Description" => "Gates between met prob thresholds"),
-                verbose=false)
         end
-        printstyled("Regenerated masks for pass $(pass+1) with threshold $(met_probs_threshold) ($(length(paths)) files)\n", color=:green)
+        printstyled("Regenerated masks for pass $(pass+1) with threshold $(met_probs_threshold) ($(length(paths)) files, $(n_sweeps_total) sweeps)\n", color=:green)
     end
 
     """
@@ -3281,62 +3316,93 @@ module Ronin
         files_done = Threads.Atomic{Int}(0)
         start_time = time()
 
+        kernel_bank_shared = config.task_mode == "convolution" ?
+            build_kernel_bank(config.conv_kernel_sizes) :
+            ConvolutionKernel[]
+
         Threads.@threads for fi in 1:n_paths
             path = paths[fi]
 
-            dims = Dataset(path) do f
-                (f.dim["range"], f.dim["time"])
+            layout, _ = NCDataset(path) do f; _detect_cfrad_layout(f); end
+            if layout == :ragged || layout == :unsupported
+                _warn_unsupported_cfrad(layout, path)
+                done = Threads.atomic_add!(files_done, 1)
+                continue
             end
 
-            if config.task_mode == "convolution"
-                config_single = deepcopy(config)
-                config_single.input_path = path
-                config_single.write_out = false
-                config_single.selected_features = md.selected_features
-                config_single.verbose = false
-                X_mask, Y_mask, idxer = calculate_features_conv(config_single, out;
-                                                                 QC_mask=QC_mask, mask_name=mask_name,
-                                                                 write_out=false, return_idxer=true)
-            else
-                currt = config.task_paths[pass]
-                cw = config.task_weights[pass]
-                X_mask, Y_mask, idxer = calculate_features(path, currt, out, true;
-                                    verbose = false,
-                                    REMOVE_LOW_SIG_QUALITY = config.REMOVE_LOW_SIG_QUALITY,
-                                    SIG_QUALITY_THRESHOLD = config.SIG_QUALITY_THRESHOLD,
-                                    SIG_QUALITY_VAR=config.SIG_QUALITY_VAR,
-                                    REMOVE_HIGH_PGG=config.REMOVE_HIGH_PGG,
-                                    PGG_THRESHOLD=config.PGG_THRESHOLD, QC_variable = config.QC_var,
-                                    remove_variable = config.remove_var,
-                                    replace_missing = config.replace_missing, return_idxer=true,
-                                    write_out = false, QC_mask = QC_mask, mask_name = mask_name,
-                                    weight_matrixes=cw)
+            NCDataset(path, "a") do f
+                for sv in sweep_views(f)
+                    dims = (dim_size(sv, "range"), dim_size(sv, "time"))
+
+                    if config.task_mode == "convolution"
+                        fm = (QC_mask && mask_name != "") ?
+                            Matrix{Bool}(.!map(ismissing, sv[mask_name][:, :])) :
+                            trues(dims)
+                        config_single = deepcopy(config)
+                        config_single.input_path = path
+                        config_single.write_out = false
+                        config_single.selected_features = md.selected_features
+                        if !isempty(md.conv_variables)
+                            config_single.conv_variables = md.conv_variables
+                        end
+                        config_single.masked_conv_variables = md.masked_conv_variables
+                        config_single.masked_conv_kernel_types = md.masked_conv_kernel_types
+                        config_single.masked_conv_kernel_sizes = md.masked_conv_kernel_sizes
+                        config_single.masked_conv_threshold = md.masked_conv_threshold
+                        config_single.masked_conv_met_prob_field = md.masked_conv_met_prob_field
+                        config_single.verbose = false
+                        result = process_single_file_conv(sv, config_single, kernel_bank_shared;
+                                                           feature_mask=fm, mask_features=QC_mask)
+                        X_mask = result[1]
+                        indexer = result[3]
+                    else
+                        currt = config.task_paths[pass]
+                        cw = config.task_weights[pass]
+                        result = process_single_file(sv, currt;
+                                                      HAS_INTERACTIVE_QC = true,
+                                                      REMOVE_LOW_SIG_QUALITY = config.REMOVE_LOW_SIG_QUALITY,
+                                                      SIG_QUALITY_THRESHOLD = config.SIG_QUALITY_THRESHOLD,
+                                                      SIG_QUALITY_VAR = config.SIG_QUALITY_VAR,
+                                                      REMOVE_HIGH_PGG = config.REMOVE_HIGH_PGG,
+                                                      PGG_THRESHOLD = config.PGG_THRESHOLD,
+                                                      QC_variable = config.QC_var,
+                                                      remove_variable = config.remove_var,
+                                                      replace_missing = config.replace_missing,
+                                                      mask_features = QC_mask,
+                                                      feature_mask = QC_mask ? Matrix{Bool}(.!map(ismissing, sv[mask_name][:, :])) : [true true; false false],
+                                                      weight_matrixes = cw)
+                        X_mask = result[1]
+                        indexer = result[3]
+                    end
+
+                    met_probs_pred = DecisionTree.predict_proba(curr_model, X_mask)
+                    if size(met_probs_pred, 2) < 2
+                        throw(DomainError(1, "ERROR: ONLY ONE CLASS IN INPUT DATASET for $(path):/$(sv.sweep_name)"))
+                    end
+                    met_probs_pred = met_probs_pred[:, 2]
+                    valid_idxs = (met_probs_pred .>= minimum(curr_metprobs)) .& (met_probs_pred .<= maximum(curr_metprobs))
+
+                    ## Save met_prob predictions into this sweep
+                    met_prob_field = Matrix{Union{Missing, Float32}}(missings(dims))[:]
+                    met_prob_idxer = copy(indexer)
+                    met_prob_field[met_prob_idxer] .= Float32.(met_probs_pred)
+                    met_prob_field = reshape(met_prob_field, dims)
+                    _define_or_overwrite!(sv, "met_prob_pass_$(pass)", met_prob_field;
+                        attribs=Dict("Units" => "probability",
+                                     "Description" => "RF meteorological probability from pass $(pass)"),
+                        verbose=false)
+
+                    ## Create mask for next pass
+                    new_mask = Matrix{Union{Missing, Float32}}(missings(dims))[:]
+                    idxer_flat = copy(indexer)
+                    idxer_flat[idxer_flat] .= Vector{Bool}(valid_idxs)
+                    new_mask[idxer_flat] .= 1.
+                    new_mask = reshape(new_mask, dims)
+                    _define_or_overwrite!(sv, config.mask_names[pass + 1], new_mask;
+                        attribs=Dict("Units" => "Bool", "Description" => "Gates between met prob thresholds"),
+                        verbose=false)
+                end
             end
-
-            met_probs_pred = DecisionTree.predict_proba(curr_model, X_mask)
-            if size(met_probs_pred, 2) < 2
-                throw(DomainError(1, "ERROR: ONLY ONE CLASS IN INPUT DATASET for $(path)"))
-            end
-            met_probs_pred = met_probs_pred[:, 2]
-            valid_idxs = (met_probs_pred .>= minimum(curr_metprobs)) .& (met_probs_pred .<= maximum(curr_metprobs))
-
-            ## Save met_prob predictions
-            met_prob_field = Matrix{Union{Missing, Float32}}(missings(dims))[:]
-            met_prob_idxer = copy(idxer[1][:])
-            met_prob_field[met_prob_idxer] .= Float32.(met_probs_pred)
-            met_prob_field = reshape(met_prob_field, dims)
-            write_field(path, "met_prob_pass_$(pass)", met_prob_field,
-                attribs=Dict("Units" => "probability",
-                             "Description" => "RF meteorological probability from pass $(pass)"))
-
-            ## Create mask for next pass
-            new_mask = Matrix{Union{Missing, Float32}}(missings(dims))[:]
-            idxer_flat = idxer[1][:]
-            idxer_flat[idxer_flat] .= Vector{Bool}(valid_idxs)
-            new_mask[idxer_flat] .= 1.
-            new_mask = reshape(new_mask, dims)
-            write_field(path, config.mask_names[pass + 1], new_mask,
-                attribs=Dict("Units" => "Bool", "Description" => "Gates between met prob thresholds"))
 
             done = Threads.atomic_add!(files_done, 1)
             if done % 50 == 0 || done == n_paths
@@ -4360,6 +4426,71 @@ module Ronin
 
         `config::ModelConfig`
     """
+    ## Per-sweep QC writer. Operates on an already-open SweepView (root for v1,
+    ## /sweep_NNNN for v2) and writes <var><QC_SUFFIX> fields into the right
+    ## subgroup. The (config, filepath, ...) form below is the legacy entry
+    ## that opens the file and delegates to this for the single sweep view.
+    function QC_scan(config::ModelConfig, v::SweepView,
+                     predictions::Vector{Bool}, init_idxer::Vector{Bool})
+
+        if config.task_mode != "convolution"
+            @assert (length(config.model_output_paths) == length(config.feature_output_paths)
+                     == length(config.met_probs) == length(config.task_paths) == length(config.task_weights) == length(config.mask_names))
+        else
+            @assert (length(config.model_output_paths) == length(config.feature_output_paths)
+                     == length(config.met_probs) == length(config.mask_names))
+        end
+
+        starttime = time()
+        sweep_dims = (dim_size(v, "range"), dim_size(v, "time"))
+
+        src_path = try; string(NCDatasets.path(v.data)); catch; "[unknown file]"; end
+        where_label = isempty(v.sweep_name) ? src_path : "$(src_path):/$(v.sweep_name)"
+
+        for var in config.VARS_TO_QC
+            printstyled("QC-ING $(var) in $(where_label)\n", color=:green)
+            NEW_FIELD = missings(Float32, sweep_dims)
+
+            if predictions != Vector{Bool}(undef, 0)
+                QCED_FIELDS = v[var][:][init_idxer]
+                NEW_FIELD_ATTRS = Dict(
+                    "units" => v[var].attrib["units"],
+                    "long_name" => "Random Forest Model QC'ed $(var) field"
+                )
+
+                initial_count = count(.!map(ismissing, QCED_FIELDS))
+                print("INITIAL COUNT: $(initial_count)")
+                QCED_FIELDS = map(x -> Bool(predictions[x[1]]) ? x[2] : missing, enumerate(QCED_FIELDS))
+                final_count = count(.!map(ismissing, QCED_FIELDS))
+
+                NEW_FIELD = NEW_FIELD[:]
+                NEW_FIELD[init_idxer] = QCED_FIELDS
+                NEW_FIELD = Matrix{Union{Missing, Float32}}(reshape(NEW_FIELD, sweep_dims))
+            else
+                NEW_FIELD = missings(Float32, sweep_dims)
+                NEW_FIELD_ATTRS = Dict(
+                    "units" => v[var].attrib["units"],
+                    "long_name" => "Random Forest Model QC'ed $(var) field"
+                )
+                initial_count = 0
+                final_count = 0
+            end
+
+            _define_or_overwrite!(v, var * config.QC_SUFFIX, NEW_FIELD;
+                                   attribs = NEW_FIELD_ATTRS,
+                                   fillval = config.FILL_VAL,
+                                   verbose = config.verbose,
+                                   context = where_label)
+
+            if config.verbose
+                println("\r\nCompleted in $(time()-starttime ) seconds")
+                println()
+                printstyled("REMOVED $(initial_count - final_count) PRESUMED NON-METEORLOGICAL DATAPOINTS\n", color=:green)
+                println("FINAL COUNT OF DATAPOINTS IN $(var): $(final_count)")
+            end
+        end
+    end
+
     function QC_scan(config::ModelConfig, filepath::String, predictions::Vector{Bool}, init_idxer::Vector{Bool})
 
         if config.task_mode != "convolution"
@@ -4543,303 +4674,291 @@ module Ronin
         ###Probably can section this off into a different function later since it's also reused in the streaming/realtime version
         for file in files
             curr_starttime = time()
-                ###Classify the CfRadial layout and skip files the gridded
-                ###feature path cannot ingest (CfRadial 2.0 hierarchical sweep
-                ###groups, ragged n_points arrays, or root layouts missing
-                ###`range`/`time`).
+                ###Classify the CfRadial layout. Ragged and unsupported layouts
+                ###are still skipped with a warning. CfRadial 2.0 is processed
+                ###natively below via per-sweep iteration (one SweepView per
+                ###/sweep_NNNN group; v1 yields a single view at root).
 
-            layout, scan_dims = redirect_stdout(devnull) do
+            layout, _ = redirect_stdout(devnull) do
                 NCDataset(file) do f
                     _detect_cfrad_layout(f)
                 end
             end
-            if layout != :ok
+            if layout == :ragged || layout == :unsupported
                 _warn_unsupported_cfrad(layout, file)
                 continue
             end
 
-            ###init_idxer contains the gates that pass the first-level QC checks (NCP, PGG) + inital mask
-            init_idxer = Vector{Bool}(undef, 0)
-            ###Keep indexer returned by the last pass of the model. This will describe where predictions
-            ###are made on the last set of gates
-            final_idxer = Vector{Bool}(undef, 0)
-
-            ###Current verification, final predictions, and probabilites
-            curr_Y = Vector{Bool}(undef, 0)
-            final_predictions = Vector{Bool}(undef, 0)
-            curr_probs = fill(-1.0, scan_dims[:])
-
-            ###For multi-pass models, iteratively construct predictions vector by applying models one at a time
-            for (i, model_path) in enumerate(config.model_output_paths)
-
-                met_prob_name = "met_prob_pass_$(i)"
-                curr_proba = config.met_probs[i]
-                met_threshold = maximum(curr_proba)
-                nmd_threshold = minimum(curr_proba)
-
-                ## --- Fast path: read saved probabilities instead of recomputing ---
-                ## When skip_existing_met_probs=true and met_prob_pass_<i> already exists,
-                ## we only need the cheap QC indexer + verification labels, not the
-                ## expensive convolution features or RF prediction.
-                can_skip_computation = false
-                if skip_existing_met_probs
-                    can_skip_computation = NCDataset(file) do ds
-                        haskey(ds, met_prob_name)
+            ###Open the file once for the whole cascade. The do-block closes
+            ###the handle (flushing writes) before we iterate the next file.
+            redirect_stdout(devnull) do
+                NCDataset(file, "a") do f
+                    views = sweep_views(f)
+                    if isempty(views)
+                        printstyled("WARNING: no QC-able sweeps in $(file); " *
+                                    "skipping\n", color=:yellow)
+                        return
                     end
-                end
+                    for v in views
+                        scan_dims = (dim_size(v, "range"), dim_size(v, "time"))
 
-                if can_skip_computation
-                    ## Read saved probabilities and build indexer cheaply
-                    f = redirect_stdout(devnull) do
-                        NCDataset(file, "r")
-                    end
+                        ###init_idxer contains the gates that pass the first-level QC checks (NCP, PGG) + inital mask
+                        init_idxer = Vector{Bool}(undef, 0)
+                        ###Keep indexer returned by the last pass of the model. This will describe where predictions
+                        ###are made on the last set of gates
+                        final_idxer = Vector{Bool}(undef, 0)
 
-                    ## Reconstruct the QC indexer (cheap — no convolutions)
-                    VT = f[config.remove_var][:]
-                    indexer = [!ismissing(x) for x in VT]
+                        ###Current verification, final predictions, and probabilites
+                        curr_Y = Vector{Bool}(undef, 0)
+                        final_predictions = Vector{Bool}(undef, 0)
+                        curr_probs = fill(-1.0, scan_dims[:])
 
-                    if i > 1
-                        mask_name = config.mask_names[i]
-                        feature_mask = Matrix{Bool}(.! map(ismissing, f[mask_name]))
-                        indexer = [indexer[j] ? feature_mask[:][j] : false for j in eachindex(indexer)]
-                    elseif config.QC_mask
-                        mask_name = config.mask_names[i]
-                        feature_mask = Matrix{Bool}(.! map(ismissing, f[mask_name]))
-                        indexer = [indexer[j] ? feature_mask[:][j] : false for j in eachindex(indexer)]
-                    end
+                        ###For multi-pass models, iteratively construct predictions vector by applying models one at a time
+                        for (i, model_path) in enumerate(config.model_output_paths)
 
-                    if config.REMOVE_HIGH_PGG
-                        PGG = [ismissing(x) || isnan(x) ? Float32(FILL_VAL) : Float32(x) for x in calc_pgg(f)[:]]
-                        indexer[indexer] = [x >= config.PGG_THRESHOLD ? false : true for x in PGG[indexer]]
-                    end
-                    if config.REMOVE_LOW_SIG_QUALITY
-                        SIG = [ismissing(x) || isnan(x) ? Float32(FILL_VAL) : Float32(x) for x in calc_sig(f, config.SIG_QUALITY_VAR)[:]]
-                        indexer[indexer] = [x <= config.SIG_QUALITY_THRESHOLD ? false : true for x in SIG[indexer]]
-                    end
+                            met_prob_name = "met_prob_pass_$(i)"
+                            curr_proba = config.met_probs[i]
+                            met_threshold = maximum(curr_proba)
+                            nmd_threshold = minimum(curr_proba)
 
-                    ## Read saved met_probs for this pass
-                    saved_probs = f[met_prob_name][:]
-                    met_probs = Float32[ismissing(x) ? Float32(-1.0) : Float32(x) for x in saved_probs[:]][indexer]
+                            ## --- Fast path: read saved probabilities instead of recomputing ---
+                            ## When skip_existing_met_probs=true and met_prob_pass_<i> already exists
+                            ## in this sweep view, we only need the cheap QC indexer + verification
+                            ## labels, not the expensive convolution features or RF prediction.
+                            can_skip_computation = skip_existing_met_probs && haskey(v, met_prob_name)
 
-                    ## Build Y if interactive QC
-                    if ((!QC_mode) && config.HAS_INTERACTIVE_QC)
-                        VG = f[config.QC_var][:][indexer]
-                        VV = f[config.remove_var][:][indexer]
-                        Y = reshape([ismissing(x) ? 0 : 1 for x in VG .- VV][:], (:, 1))
-                    else
-                        Y = false
-                    end
+                            if can_skip_computation
+                                ## Reconstruct the QC indexer (cheap — no convolutions)
+                                VT = v[config.remove_var][:]
+                                indexer = [!ismissing(x) for x in VT]
 
-                    close(f)
+                                if i > 1
+                                    mask_name = config.mask_names[i]
+                                    feature_mask = Matrix{Bool}(.! map(ismissing, v[mask_name]))
+                                    indexer = [indexer[j] ? feature_mask[:][j] : false for j in eachindex(indexer)]
+                                elseif config.QC_mask
+                                    mask_name = config.mask_names[i]
+                                    feature_mask = Matrix{Bool}(.! map(ismissing, v[mask_name]))
+                                    indexer = [indexer[j] ? feature_mask[:][j] : false for j in eachindex(indexer)]
+                                end
 
-                    final_idxer = indexer
-                    curr_probs[indexer] .= met_probs[:]
+                                if config.REMOVE_HIGH_PGG
+                                    PGG = [ismissing(x) || isnan(x) ? Float32(FILL_VAL) : Float32(x) for x in calc_pgg(v)[:]]
+                                    indexer[indexer] = [x >= config.PGG_THRESHOLD ? false : true for x in PGG[indexer]]
+                                end
+                                if config.REMOVE_LOW_SIG_QUALITY
+                                    SIG = [ismissing(x) || isnan(x) ? Float32(FILL_VAL) : Float32(x) for x in calc_sig(v, config.SIG_QUALITY_VAR)[:]]
+                                    indexer[indexer] = [x <= config.SIG_QUALITY_THRESHOLD ? false : true for x in SIG[indexer]]
+                                end
 
-                    append!(pass_probs[i], met_probs)
+                                ## Read saved met_probs for this pass
+                                saved_probs = v[met_prob_name][:]
+                                met_probs = Float32[ismissing(x) ? Float32(-1.0) : Float32(x) for x in saved_probs[:]][indexer]
 
-                    if i == 1
-                        init_idxer = copy(indexer)
-                        curr_Y = copy(Y)
-                        final_predictions = fill(false, sum(indexer))
-                        final_predictions[met_probs .< nmd_threshold] .= false
-                        final_predictions[met_probs .> met_threshold] .= true
-                    elseif i == config.num_models
-                        valid_idxs = indexer[init_idxer]
-                        curr_preds = final_predictions[valid_idxs]
-                        curr_preds[met_probs .>= met_threshold] .= true
-                        curr_preds[met_probs .<  nmd_threshold] .= false
-                        final_predictions[valid_idxs] .= curr_preds
-                    else
-                        valid_idxs = indexer[init_idxer]
-                        curr_preds = final_predictions[valid_idxs]
-                        curr_preds[met_probs .< nmd_threshold] .= false
-                        curr_preds[met_probs .> met_threshold] .= true
-                        final_predictions[valid_idxs] .= curr_preds
-                    end
+                                ## Build Y if interactive QC
+                                if ((!QC_mode) && config.HAS_INTERACTIVE_QC)
+                                    VG = v[config.QC_var][:][indexer]
+                                    VV = v[config.remove_var][:][indexer]
+                                    Y = reshape([ismissing(x) ? 0 : 1 for x in VG .- VV][:], (:, 1))
+                                else
+                                    Y = false
+                                end
 
-                    continue
-                end
+                                final_idxer = indexer
+                                curr_probs[indexer] .= met_probs[:]
 
-                ## --- Normal path: compute features and run RF prediction ---
+                                append!(pass_probs[i], met_probs)
 
-                ###REFACTOR NOTES: I THINK PROCESS_SINGLE_FILE CLOSES THE FILE SO WILL NEED TO CHANGE THAT
-                ###TO MOVE OUTSIDE LOOP
-                ###We don't need to write these out, just use them briefly
-                f = redirect_stdout(devnull) do
-                    NCDataset(file, "a")
-                end
+                                if i == 1
+                                    init_idxer = copy(indexer)
+                                    curr_Y = copy(Y)
+                                    final_predictions = fill(false, sum(indexer))
+                                    final_predictions[met_probs .< nmd_threshold] .= false
+                                    final_predictions[met_probs .> met_threshold] .= true
+                                elseif i == config.num_models
+                                    valid_idxs = indexer[init_idxer]
+                                    curr_preds = final_predictions[valid_idxs]
+                                    curr_preds[met_probs .>= met_threshold] .= true
+                                    curr_preds[met_probs .<  nmd_threshold] .= false
+                                    final_predictions[valid_idxs] .= curr_preds
+                                else
+                                    valid_idxs = indexer[init_idxer]
+                                    curr_preds = final_predictions[valid_idxs]
+                                    curr_preds[met_probs .< nmd_threshold] .= false
+                                    curr_preds[met_probs .> met_threshold] .= true
+                                    final_predictions[valid_idxs] .= curr_preds
+                                end
 
-                if i > 1
-                    QC_mask = true
-                else
-                    QC_mask = config.QC_mask
-                end
+                                continue
+                            end
 
-                QC_mask ? mask_name = config.mask_names[i] : mask_name = ""
+                            ## --- Normal path: compute features and run RF prediction ---
 
-                if QC_mask
-                    feature_mask = Matrix{Bool}(.! map(ismissing, f[mask_name]))
-                else
-                    feature_mask = [true true; false false]
-                end
+                            if i > 1
+                                QC_mask = true
+                            else
+                                QC_mask = config.QC_mask
+                            end
+
+                            QC_mask ? mask_name = config.mask_names[i] : mask_name = ""
+
+                            if QC_mask
+                                feature_mask = Matrix{Bool}(.! map(ismissing, v[mask_name]))
+                            else
+                                feature_mask = [true true; false false]
+                            end
 
 
-                ###If there are zero features of interest because they've all been masked out, we're done. Continue to next model, and eventaully to next file
-                if sum(feature_mask) == 0
-                    break
-                end
+                            ###If there are zero features of interest because they've all been masked out, we're done. Continue to next model, and eventaully to next file
+                            if sum(feature_mask) == 0
+                                break
+                            end
 
-                ###Need to actually pass the QC mask
-                ###indexer will contain true where gates in the file both were NOT masked out AND met the basic QC thresholds
+                            ###Need to actually pass the QC mask
+                            ###indexer will contain true where gates in the file both were NOT masked out AND met the basic QC thresholds
 
-                if config.task_mode == "convolution"
-                    kernel_bank = build_kernel_bank(config.conv_kernel_sizes)
-                    config_pred = deepcopy(config)
-                    config_pred.HAS_INTERACTIVE_QC = ((!QC_mode) && config.HAS_INTERACTIVE_QC)
-                    config_pred.selected_features = model_selected_features[i]
-                    if !isempty(model_conv_variables[i])
-                        config_pred.conv_variables = model_conv_variables[i]
-                    end
-                    config_pred.masked_conv_variables = model_masked_conv_variables[i]
-                    config_pred.masked_conv_kernel_types = model_masked_conv_kernel_types[i]
-                    config_pred.masked_conv_kernel_sizes = model_masked_conv_kernel_sizes[i]
-                    config_pred.masked_conv_threshold = model_masked_conv_thresholds[i]
-                    config_pred.masked_conv_met_prob_field = model_masked_conv_met_prob_fields[i]
-                    result = process_single_file_conv(f, config_pred, kernel_bank;
-                                                      feature_mask=feature_mask, mask_features=QC_mask)
-                    X, Y, indexer = result[1], result[2], result[3]
-                    _check_feature_width(X, model_selected_features[i], model_feature_names[i], model_path, i)
-                else
-                    currt = config.task_paths[i]
-                    cw = config.task_weights[i]
-                    X, Y, indexer = process_single_file(f, currt, HAS_INTERACTIVE_QC = ((! QC_mode) && config.HAS_INTERACTIVE_QC)
-                        , REMOVE_HIGH_PGG = config.REMOVE_HIGH_PGG, PGG_THRESHOLD = config.PGG_THRESHOLD,
-                        REMOVE_LOW_SIG_QUALITY = config.REMOVE_LOW_SIG_QUALITY, SIG_QUALITY_THRESHOLD = config.SIG_QUALITY_THRESHOLD, SIG_QUALITY_VAR = config.SIG_QUALITY_VAR,
-                        QC_variable = config.QC_var, replace_missing = config.replace_missing, remove_variable = config.remove_var,
-                        mask_features = QC_mask, feature_mask = feature_mask, weight_matrixes=cw)
-                end
-                final_idxer = indexer
-                ###If there are no gates that meet the basic QC thresholds now, we're once again done.
-                if sum(indexer) != 0
+                            if config.task_mode == "convolution"
+                                kernel_bank = build_kernel_bank(config.conv_kernel_sizes)
+                                config_pred = deepcopy(config)
+                                config_pred.HAS_INTERACTIVE_QC = ((!QC_mode) && config.HAS_INTERACTIVE_QC)
+                                config_pred.selected_features = model_selected_features[i]
+                                if !isempty(model_conv_variables[i])
+                                    config_pred.conv_variables = model_conv_variables[i]
+                                end
+                                config_pred.masked_conv_variables = model_masked_conv_variables[i]
+                                config_pred.masked_conv_kernel_types = model_masked_conv_kernel_types[i]
+                                config_pred.masked_conv_kernel_sizes = model_masked_conv_kernel_sizes[i]
+                                config_pred.masked_conv_threshold = model_masked_conv_thresholds[i]
+                                config_pred.masked_conv_met_prob_field = model_masked_conv_met_prob_fields[i]
+                                result = process_single_file_conv(v, config_pred, kernel_bank;
+                                                                  feature_mask=feature_mask, mask_features=QC_mask)
+                                X, Y, indexer = result[1], result[2], result[3]
+                                _check_feature_width(X, model_selected_features[i], model_feature_names[i], model_path, i)
+                            else
+                                currt = config.task_paths[i]
+                                cw = config.task_weights[i]
+                                X, Y, indexer = process_single_file(v, currt, HAS_INTERACTIVE_QC = ((! QC_mode) && config.HAS_INTERACTIVE_QC)
+                                    , REMOVE_HIGH_PGG = config.REMOVE_HIGH_PGG, PGG_THRESHOLD = config.PGG_THRESHOLD,
+                                    REMOVE_LOW_SIG_QUALITY = config.REMOVE_LOW_SIG_QUALITY, SIG_QUALITY_THRESHOLD = config.SIG_QUALITY_THRESHOLD, SIG_QUALITY_VAR = config.SIG_QUALITY_VAR,
+                                    QC_variable = config.QC_var, replace_missing = config.replace_missing, remove_variable = config.remove_var,
+                                    mask_features = QC_mask, feature_mask = feature_mask, weight_matrixes=cw)
+                            end
+                            final_idxer = indexer
+                            ###If there are no gates that meet the basic QC thresholds now, we're once again done.
+                            if sum(indexer) != 0
 
-                    curr_model = models[i]
-                    ###Here's where we need to modify. The ONLY gates that will go on to the next pass
-                    ### will be the ones between the thresholds, (inclusive on both ends)
+                                curr_model = models[i]
+                                ###Here's where we need to modify. The ONLY gates that will go on to the next pass
+                                ### will be the ones between the thresholds, (inclusive on both ends)
 
-                    met_probs = DecisionTree.predict_proba(curr_model, X)[:, 2]
-                    curr_probs[indexer] .= met_probs[:]
-                    append!(pass_probs[i], Float32.(met_probs))
+                                met_probs = DecisionTree.predict_proba(curr_model, X)[:, 2]
+                                curr_probs[indexer] .= met_probs[:]
+                                append!(pass_probs[i], Float32.(met_probs))
 
-                    if i == 1
-                        init_idxer = copy(indexer)
-                        curr_Y = copy(Y)
-                        ###Instantiate prediction vector - the gates that meet the basic thresholds/masking on pass 1 are the ones we want to predict on
-                        final_predictions = fill(false, sum(indexer))
-                            ###Set gates below predicted threshold to non-met
-                        final_predictions[met_probs .< nmd_threshold] .= false
-                        final_predictions[met_probs .> met_threshold] .= true
+                                if i == 1
+                                    init_idxer = copy(indexer)
+                                    curr_Y = copy(Y)
+                                    ###Instantiate prediction vector - the gates that meet the basic thresholds/masking on pass 1 are the ones we want to predict on
+                                    final_predictions = fill(false, sum(indexer))
+                                        ###Set gates below predicted threshold to non-met
+                                    final_predictions[met_probs .< nmd_threshold] .= false
+                                    final_predictions[met_probs .> met_threshold] .= true
 
-                    elseif i == config.num_models
-                        ###Some weird syntax here because Julia doesn't like double indexing
-                        ###Grab spots in the scan where the gates were both passing minimum quality control thresholds
-                        ###and also have passed previous passes. Do this to ensure dimensional consistency with the
-                        ###final prediction vector.
-                        valid_idxs = indexer[init_idxer]
-                        ###Grab locations in the prediction vector where this pass is being applied.
-                        curr_preds = final_predictions[valid_idxs]
-                        ###Final pass: just take the model's (majority vote) predictions for the class of the gates and we're done!
-                        curr_preds[met_probs .>= met_threshold] .= true
-                        curr_preds[met_probs .<  nmd_threshold] .= false
-                        ###Reassign
-                        final_predictions[valid_idxs] .= curr_preds
-                    else
-                        ###Indexer has NOT yet been applied so index in to the existing predictions
-                        valid_idxs = indexer[init_idxer]
-                        ###Grab locations in the prediction vector where this pass is being applied.
-                        curr_preds = final_predictions[valid_idxs]
-                        curr_preds[met_probs .< nmd_threshold] .= false
-                        curr_preds[met_probs .> met_threshold] .= true
+                                elseif i == config.num_models
+                                    ###Some weird syntax here because Julia doesn't like double indexing
+                                    ###Grab spots in the scan where the gates were both passing minimum quality control thresholds
+                                    ###and also have passed previous passes. Do this to ensure dimensional consistency with the
+                                    ###final prediction vector.
+                                    valid_idxs = indexer[init_idxer]
+                                    ###Grab locations in the prediction vector where this pass is being applied.
+                                    curr_preds = final_predictions[valid_idxs]
+                                    ###Final pass: just take the model's (majority vote) predictions for the class of the gates and we're done!
+                                    curr_preds[met_probs .>= met_threshold] .= true
+                                    curr_preds[met_probs .<  nmd_threshold] .= false
+                                    ###Reassign
+                                    final_predictions[valid_idxs] .= curr_preds
+                                else
+                                    ###Indexer has NOT yet been applied so index in to the existing predictions
+                                    valid_idxs = indexer[init_idxer]
+                                    ###Grab locations in the prediction vector where this pass is being applied.
+                                    curr_preds = final_predictions[valid_idxs]
+                                    curr_preds[met_probs .< nmd_threshold] .= false
+                                    curr_preds[met_probs .> met_threshold] .= true
 
-                        final_predictions[valid_idxs] .= curr_preds
+                                    final_predictions[valid_idxs] .= curr_preds
 
-                    end
-                    close(f)
-                    ###If this wasn't the last pass, write met_prob and mask for the next pass
-                    if i < config.num_models
-                        mask_name_next = config.mask_names[i+1]
+                                end
+                                ###If this wasn't the last pass, write met_prob and mask for the next pass
+                                if i < config.num_models
+                                    mask_name_next = config.mask_names[i+1]
 
-                        ## Write met_prob_pass_<i> so the next pass can use it as a feature
-                        met_prob_field = Matrix{Union{Missing, Float32}}(missings(scan_dims))[:]
-                        met_prob_field[indexer] .= met_probs
-                        met_prob_field = reshape(met_prob_field, scan_dims)
-                        write_field(file, met_prob_name, met_prob_field,
-                            attribs=Dict("Units" => "Probability", "Description" => "Meteorological probability from pass $(i)"),
-                            fillval=config.FILL_VAL, verbose=false)
+                                    ## Write met_prob_pass_<i> so the next pass can use it as a feature
+                                    met_prob_field = Matrix{Union{Missing, Float32}}(missings(scan_dims))[:]
+                                    met_prob_field[indexer] .= met_probs
+                                    met_prob_field = reshape(met_prob_field, scan_dims)
+                                    _define_or_overwrite!(v, met_prob_name, met_prob_field;
+                                        attribs=Dict("Units" => "Probability", "Description" => "Meteorological probability from pass $(i)"),
+                                        fillval=config.FILL_VAL, verbose=false)
 
-                        ## Write mask for gates between thresholds
-                        gates_of_interest = (met_probs .>= nmd_threshold) .& (met_probs .<= met_threshold)
-                        new_mask = Matrix{Union{Missing, Float32}}(missings(scan_dims))[:]
-                        if sum(gates_of_interest) != 0
-                            @assert length(gates_of_interest) == sum(indexer)
-                            indexer[indexer] .= gates_of_interest
-                            new_mask[indexer] .= 1.
+                                    ## Write mask for gates between thresholds
+                                    gates_of_interest = (met_probs .>= nmd_threshold) .& (met_probs .<= met_threshold)
+                                    new_mask = Matrix{Union{Missing, Float32}}(missings(scan_dims))[:]
+                                    if sum(gates_of_interest) != 0
+                                        @assert length(gates_of_interest) == sum(indexer)
+                                        indexer[indexer] .= gates_of_interest
+                                        new_mask[indexer] .= 1.
+                                    end
+                                    new_mask = reshape(new_mask, scan_dims)
+                                    _define_or_overwrite!(v, mask_name_next, new_mask;
+                                        attribs=Dict("Units" => "Bool", "Description" => "Gates between met prob thresholds"),
+                                        fillval=config.FILL_VAL, verbose=false)
+                                end
+
+                                ## Save met_prob for final pass too, so threshold sweeps can skip recomputation
+                                if i == config.num_models
+                                    met_prob_field = Matrix{Union{Missing, Float32}}(missings(scan_dims))[:]
+                                    met_prob_field[indexer] .= met_probs
+                                    met_prob_field = reshape(met_prob_field, scan_dims)
+                                    _define_or_overwrite!(v, met_prob_name, met_prob_field;
+                                        attribs=Dict("Units" => "Probability", "Description" => "Meteorological probability from pass $(i)"),
+                                        fillval=config.FILL_VAL, verbose=false)
+                                end
+                            else
+                                ###If the sum of the indexer is zero, we're done. There's nothing to predict upon.
+                                ###This will only happen on the first pass of the model, so we won't have to worry about actually making a prediction
+                                break
+                            end
+
+
+                        end # end pass loop
+
+
+                        ###Probably put the below into a separate function for code clarity
+                        if QC_mode
+                            QC_scan(config, v, Vector{Bool}(final_predictions), Vector{Bool}(init_idxer))
+                            if config.verbose
+                                printstyled("COMPLETED FULL QC OF $(file)" *
+                                            (isempty(v.sweep_name) ? "" : ":/$(v.sweep_name)") *
+                                            " IN $(round((time() - curr_starttime), digits = 2)) SECONDS\n",
+                                            color=:green)
+                            end
+                        else
+                            if final_predictions != Vector{Bool}(undef, 0)
+                                ##Add indexer to the indexer list
+                                push!(init_idxers, init_idxer)
+                                ###Add verification to full array
+                                values = vcat(values, curr_Y)
+                                ##We only care about the probabilities where the indexer is
+                                total_met_probs = vcat(total_met_probs, curr_probs[:][init_idxer])
+
+                                ###Add on to final predictions
+                                ###Prediction vector has been interatively constructed so will comport with the verification
+                                predictions = vcat(predictions, final_predictions)
+                            end
                         end
-                        new_mask = reshape(new_mask, scan_dims)
-                        write_field(file, mask_name_next, new_mask,  attribs=Dict("Units" => "Bool", "Description" => "Gates between met prob thresholds"), fillval=config.FILL_VAL, verbose=false)
-                    end
-
-                    ## Save met_prob for final pass too, so threshold sweeps can skip recomputation
-                    if i == config.num_models
-                        met_prob_field = Matrix{Union{Missing, Float32}}(missings(scan_dims))[:]
-                        met_prob_field[indexer] .= met_probs
-                        met_prob_field = reshape(met_prob_field, scan_dims)
-                        write_field(file, met_prob_name, met_prob_field,
-                            attribs=Dict("Units" => "Probability", "Description" => "Meteorological probability from pass $(i)"),
-                            fillval=config.FILL_VAL, verbose=false)
-                    end
-                else
-                    ###If the sum of the indexer is zero, we're done. There's nothing to predict upon.
-                    ###This will only happen on the first pass of the model, so we won't have to worry about actually making a prediction
-                    break
-                end
-
-
-            end
-
-
-            ###Probably put the below into a separate function for code clarity
-            if QC_mode
-                QC_scan(config, file, Vector{Bool}(final_predictions), Vector{Bool}(init_idxer))
-                if config.verbose
-                    printstyled("COMPLETED FULL QC OF $(file) IN $(round((time() - curr_starttime), digits = 2)) SECONDS\n", color=:green)
-                end
-            else
-                if final_predictions != Vector{Bool}(undef, 0)
-                    ##Add indexer to the indexer list
-                    push!(init_idxers, init_idxer)
-                    ###Add verification to full array
-                    values = vcat(values, curr_Y)
-                    ##We only care about the probabilities where the indexer is
-                    total_met_probs = vcat(total_met_probs, curr_probs[:][init_idxer])
-                    ##First need to determine the differenc between the initial indexer and the full scan?
-
-                                # ###init_indexer contains the gates in the scan that did not meet the basic quality control thresholds.
-                                # ###A space will be needed in the predictions for each positive value here.
-                                # ###Difference of final_indxer and init_index contains gates that were marked as non-meteorological throughout the course
-                                # ###of applying the composite model. The final prediction then is ONLY on the gates that are still valid
-                                # ###in final_idxer
-                                # ###We are interested in returning the predictions and the validation for a set of gates
-                                # curr_predictions = fill(false, (sum(init_idxer)))
-                                # ###The only gates the final pass of the model applied a prediction to will be those where
-                                # ###BOTH the final indexer and the initial indexer flagged as valid. Assign the model predictions to these gates.
-                                # pred_idxer = (final_idxer[init_idxer] .== true)
-                                # curr_predictions[pred_idxer] = final_predictions
-
-                    ###Add on to final predictions
-                    ###Prediction vector has been interatively constructed so will comport with the verification
-                    predictions = vcat(predictions, final_predictions)
-                end
-            end
+                    end # end sweep loop
+                end # end NCDataset do-block
+            end # end redirect_stdout
 
         end
 
@@ -5604,191 +5723,197 @@ module Ronin
                 if isdir(file)
                     continue
                 end
-                ###Classify the CfRadial layout and skip files that the gridded
-                ###feature path cannot ingest (CfRadial 2.0 hierarchical sweep
-                ###groups, ragged n_points arrays, or root layouts missing
-                ###`range`/`time`). This keeps process_day_chunks alive on a
-                ###mixed-format batch instead of crashing the whole volume.
-                layout, scan_dims = NCDataset(file) do f
+                ###Classify the CfRadial layout. Ragged-array files and any
+                ###file missing root `range`/`time` for non-v2 reasons are still
+                ###skipped with a warning so process_day_chunks survives a
+                ###mixed-format batch. CfRadial 2.0 is handled natively below
+                ###via the per-sweep iteration (one SweepView per /sweep_NNNN).
+                layout, _ = NCDataset(file) do f
                     _detect_cfrad_layout(f)
                 end
-                if layout != :ok
+                if layout == :ragged || layout == :unsupported
                     _warn_unsupported_cfrad(layout, file)
                     continue
                 end
 
-                ###init_idxer contains the gates that pass the first-level QC checks (NCP, PGG) + inital mask
-                init_idxer = Vector{Bool}(undef, 0)
-                ###Keep indexer returned by the last pass of the model. This will describe where predictions
-                ###are made on the last set of gates
-                final_idxer = Vector{Bool}(undef, 0)
-
-                ###Current verification, final predictions, and probabilites
-                curr_Y = Vector{Bool}(undef, 0)
-                final_predictions = Vector{Bool}(undef, 0)
-                curr_probs = fill(-1.0, scan_dims[:])
-
-                ###For multi-pass models, iteratively construct predictions vector by applying models one at a time
-                # Initialize QC mask as the original mask specified in the config. This will be updated to be the new mask after each pass of the model, but we need to start with the original mask for the first pass.
-                QC_mask = config.QC_mask
-                for (i, model_path) in enumerate(config.model_output_paths)
-
-                    ###REFACTOR NOTES: I THINK PROCESS_SINGLE_FILE CLOSES THE FILE SO WILL NEED TO CHANGE THAT
-                    ###TO MOVE OUTSIDE LOOP
-                    ###We don't need to write these out, just use them briefly
-                    f = redirect_stdout(devnull) do
-                        NCDataset(file, "a")
+                ###Open the file once for the whole cascade (across all sweeps,
+                ###all passes). Each pass writes back into the same handle.
+                NCDataset(file, "a") do f
+                    views = sweep_views(f)
+                    if isempty(views)
+                        printstyled("WARNING: no QC-able sweeps in $(file); " *
+                                    "skipping\n", color=:yellow)
+                        return
                     end
+                    for v in views
+                        scan_dims = (dim_size(v, "range"), dim_size(v, "time"))
 
-                    if i > 1
-                        QC_mask = true
-                    else
+                        ###init_idxer contains the gates that pass the first-level QC checks (NCP, PGG) + inital mask
+                        init_idxer = Vector{Bool}(undef, 0)
+                        ###Keep indexer returned by the last pass of the model. This will describe where predictions
+                        ###are made on the last set of gates
+                        final_idxer = Vector{Bool}(undef, 0)
+
+                        ###Current verification, final predictions, and probabilites
+                        curr_Y = Vector{Bool}(undef, 0)
+                        final_predictions = Vector{Bool}(undef, 0)
+                        curr_probs = fill(-1.0, scan_dims[:])
+
+                        ###For multi-pass models, iteratively construct predictions vector by applying models one at a time
+                        # Initialize QC mask as the original mask specified in the config. This will be updated to be the new mask after each pass of the model, but we need to start with the original mask for the first pass.
                         QC_mask = config.QC_mask
-                    end
+                        for (i, model_path) in enumerate(config.model_output_paths)
 
-                    QC_mask ? mask_name = config.mask_names[i] : mask_name = ""
-
-                    if QC_mask
-                        feature_mask = Matrix{Bool}(.! map(ismissing, f[mask_name]))
-                    else
-                        feature_mask = [true true; false false]
-                    end
-
-
-                    ###If there are zero features of interest because they've all been masked out, we're done. Continue to next model, and eventaully to next file
-                    if sum(feature_mask) == 0
-                        break
-                    end
-
-                    ###Need to actually pass the QC mask
-                    ###indexer will contain true where gates in the file both were NOT masked out AND met the basic QC thresholds
-                    if config.task_mode == "convolution"
-                        config_pred = deepcopy(config)
-                        config_pred.HAS_INTERACTIVE_QC = false
-                        config_pred.selected_features = model_selected_features[i]
-                        if !isempty(model_conv_variables[i])
-                            config_pred.conv_variables = model_conv_variables[i]
-                        end
-                        config_pred.masked_conv_variables = model_masked_conv_variables[i]
-                        config_pred.masked_conv_kernel_types = model_masked_conv_kernel_types[i]
-                        config_pred.masked_conv_kernel_sizes = model_masked_conv_kernel_sizes[i]
-                        config_pred.masked_conv_threshold = model_masked_conv_thresholds[i]
-                        config_pred.masked_conv_met_prob_field = model_masked_conv_met_prob_fields[i]
-                        result = process_single_file_conv(f, config_pred, kernel_bank;
-                                                          feature_mask=feature_mask, mask_features=QC_mask)
-                        X, Y, indexer = result[1], result[2], result[3]
-                        _check_feature_width(X, model_selected_features[i], model_feature_names[i], model_path, i)
-                    else
-                        currt = config.task_paths[i]
-                        cw = config.task_weights[i]
-                        X, Y, indexer = process_single_file(f, currt, HAS_INTERACTIVE_QC = ((! true) && config.HAS_INTERACTIVE_QC)
-                            , REMOVE_HIGH_PGG = config.REMOVE_HIGH_PGG, PGG_THRESHOLD = config.PGG_THRESHOLD,
-                            REMOVE_LOW_SIG_QUALITY = config.REMOVE_LOW_SIG_QUALITY, SIG_QUALITY_THRESHOLD = config.SIG_QUALITY_THRESHOLD, SIG_QUALITY_VAR = config.SIG_QUALITY_VAR,
-                            QC_variable = config.QC_var, replace_missing = config.replace_missing, remove_variable = config.remove_var,
-                            mask_features = QC_mask, feature_mask = feature_mask, weight_matrixes=cw)
-                    end
-                    final_idxer = indexer
-
-                    ###If there are no gates that meet the basic QC thresholds now, we're once again done.
-                    if sum(indexer) != 0
-
-                        curr_model = models[i]
-                        curr_proba = config.met_probs[i]
-                        met_prob_name = "met_prob_pass_$(i)"
-                        ###Here's where we need to modify. The ONLY gates that will go on to the next pass
-                        ### will be the ones between the thresholds, (inclusive on both ends)
-
-                        met_probs = DecisionTree.predict_proba(curr_model, X)[:, 2]
-                        curr_probs[indexer] .= met_probs[:]
-
-                        met_threshold = maximum(curr_proba)
-                        nmd_threshold = minimum(curr_proba)
-
-                        if i == 1
-                            init_idxer = copy(indexer)
-                            curr_Y = copy(Y)
-                            ###Instantiate prediction vector - the gates that meet the basic thresholds/masking on pass 1 are the ones we want to predict on
-                            final_predictions = fill(false, sum(indexer))
-                                ###Set gates below predicted threshold to non-met
-                            final_predictions[met_probs .< nmd_threshold] .= false
-                            final_predictions[met_probs .> met_threshold] .= true
-
-                        elseif i == config.num_models
-                            ###Some weird syntax here because Julia doesn't like double indexing
-                            ###Grab spots in the scan where the gates were both passing minimum quality control thresholds
-                            ###and also have passed previous passes. Do this to ensure dimensional consistency with the
-                            ###final prediction vector.
-                            valid_idxs = indexer[init_idxer]
-                            ###Grab locations in the prediction vector where this pass is being applied.
-                            curr_preds = final_predictions[valid_idxs]
-                            ###Final pass: just take the model's (majority vote) predictions for the class of the gates and we're done!
-                            curr_preds[met_probs .>= met_threshold] .= true
-                            curr_preds[met_probs .<  nmd_threshold] .= false
-                            ###Reassign
-                            final_predictions[valid_idxs] .= curr_preds
-                        else
-                            ###Indexer has NOT yet been applied so index in to the existing predictions
-                            valid_idxs = indexer[init_idxer]
-                            ###Grab locations in the prediction vector where this pass is being applied.
-                            curr_preds = final_predictions[valid_idxs]
-                            curr_preds[met_probs .< nmd_threshold] .= false
-                            curr_preds[met_probs .> met_threshold] .= true
-
-                            final_predictions[valid_idxs] .= curr_preds
-
-                        end
-                        close(f)
-                        ###Probably need to remove this for speed purposes... keep it in memory,
-                        ###clear it for the next scan. Just pass it to QC_mask
-                        ###If this wasn't the last pass, write met_prob and mask for the next pass.
-                        ###The met_prob_pass_<i> write-back is required: subsequent passes
-                        ###(e.g. fore_mask Pass 2) consume met_prob_pass_<i> both as a plain
-                        ###conv variable and as the masked-conv met_prob field. Without it the
-                        ###masked-conv block is silently dropped, producing a too-narrow feature
-                        ###matrix and a BoundsError deep in the RF. Mirrors composite_prediction.
-                        if i < config.num_models
-                            met_prob_field = Matrix{Union{Missing, Float32}}(missings(scan_dims))[:]
-                            met_prob_field[indexer] .= met_probs
-                            met_prob_field = reshape(met_prob_field, scan_dims)
-                            write_field(file, met_prob_name, met_prob_field,
-                                attribs=Dict("Units" => "Probability", "Description" => "Meteorological probability from pass $(i)"),
-                                fillval=config.FILL_VAL, verbose=false)
-
-                            gates_of_interest = (met_probs .>= nmd_threshold) .& (met_probs .<= met_threshold)
-                            new_mask = Matrix{Union{Missing, Float32}}(missings(scan_dims))[:]
-                            ###If there are no gates of interest, write out the mask as ALL MISSINGS
-                            ###Otherwise, fill in the gates of interest with 1's
-                            if sum(gates_of_interest) != 0
-                                @assert length(gates_of_interest) == sum(indexer)
-                                indexer[indexer] .= gates_of_interest
-                                new_mask[indexer] .= 1.
+                            if i > 1
+                                QC_mask = true
+                            else
+                                QC_mask = config.QC_mask
                             end
-                            new_mask = reshape(new_mask, scan_dims)
-                            write_field(file, config.mask_names[i+1], new_mask,  attribs=Dict("Units" => "Bool", "Description" => "Gates between met prob thresholds"), fillval=config.FILL_VAL)
-                         end
 
-                        ###Save met_prob for the final pass too, so threshold sweeps /
-                        ###downstream tooling can read it back without recomputation.
-                        if i == config.num_models
-                            met_prob_field = Matrix{Union{Missing, Float32}}(missings(scan_dims))[:]
-                            met_prob_field[indexer] .= met_probs
-                            met_prob_field = reshape(met_prob_field, scan_dims)
-                            write_field(file, met_prob_name, met_prob_field,
-                                attribs=Dict("Units" => "Probability", "Description" => "Meteorological probability from pass $(i)"),
-                                fillval=config.FILL_VAL, verbose=false)
-                        end
-                    else
-                        ###If the sum of the indexer is zero, we're done. There's nothing to predict upon.
-                        ###This will only happen on the first pass of the model, so we won't have to worry about actually making a prediction
-                        break
-                    end
+                            QC_mask ? mask_name = config.mask_names[i] : mask_name = ""
+
+                            if QC_mask
+                                feature_mask = Matrix{Bool}(.! map(ismissing, v[mask_name]))
+                            else
+                                feature_mask = [true true; false false]
+                            end
 
 
-                end
+                            ###If there are zero features of interest because they've all been masked out, we're done. Continue to next model, and eventaully to next file
+                            if sum(feature_mask) == 0
+                                break
+                            end
+
+                            ###Need to actually pass the QC mask
+                            ###indexer will contain true where gates in the file both were NOT masked out AND met the basic QC thresholds
+                            if config.task_mode == "convolution"
+                                config_pred = deepcopy(config)
+                                config_pred.HAS_INTERACTIVE_QC = false
+                                config_pred.selected_features = model_selected_features[i]
+                                if !isempty(model_conv_variables[i])
+                                    config_pred.conv_variables = model_conv_variables[i]
+                                end
+                                config_pred.masked_conv_variables = model_masked_conv_variables[i]
+                                config_pred.masked_conv_kernel_types = model_masked_conv_kernel_types[i]
+                                config_pred.masked_conv_kernel_sizes = model_masked_conv_kernel_sizes[i]
+                                config_pred.masked_conv_threshold = model_masked_conv_thresholds[i]
+                                config_pred.masked_conv_met_prob_field = model_masked_conv_met_prob_fields[i]
+                                result = process_single_file_conv(v, config_pred, kernel_bank;
+                                                                  feature_mask=feature_mask, mask_features=QC_mask)
+                                X, Y, indexer = result[1], result[2], result[3]
+                                _check_feature_width(X, model_selected_features[i], model_feature_names[i], model_path, i)
+                            else
+                                currt = config.task_paths[i]
+                                cw = config.task_weights[i]
+                                X, Y, indexer = process_single_file(v, currt, HAS_INTERACTIVE_QC = ((! true) && config.HAS_INTERACTIVE_QC)
+                                    , REMOVE_HIGH_PGG = config.REMOVE_HIGH_PGG, PGG_THRESHOLD = config.PGG_THRESHOLD,
+                                    REMOVE_LOW_SIG_QUALITY = config.REMOVE_LOW_SIG_QUALITY, SIG_QUALITY_THRESHOLD = config.SIG_QUALITY_THRESHOLD, SIG_QUALITY_VAR = config.SIG_QUALITY_VAR,
+                                    QC_variable = config.QC_var, replace_missing = config.replace_missing, remove_variable = config.remove_var,
+                                    mask_features = QC_mask, feature_mask = feature_mask, weight_matrixes=cw)
+                            end
+                            final_idxer = indexer
+
+                            ###If there are no gates that meet the basic QC thresholds now, we're once again done.
+                            if sum(indexer) != 0
+
+                                curr_model = models[i]
+                                curr_proba = config.met_probs[i]
+                                met_prob_name = "met_prob_pass_$(i)"
+                                ###Here's where we need to modify. The ONLY gates that will go on to the next pass
+                                ### will be the ones between the thresholds, (inclusive on both ends)
+
+                                met_probs = DecisionTree.predict_proba(curr_model, X)[:, 2]
+                                curr_probs[indexer] .= met_probs[:]
+
+                                met_threshold = maximum(curr_proba)
+                                nmd_threshold = minimum(curr_proba)
+
+                                if i == 1
+                                    init_idxer = copy(indexer)
+                                    curr_Y = copy(Y)
+                                    ###Instantiate prediction vector - the gates that meet the basic thresholds/masking on pass 1 are the ones we want to predict on
+                                    final_predictions = fill(false, sum(indexer))
+                                        ###Set gates below predicted threshold to non-met
+                                    final_predictions[met_probs .< nmd_threshold] .= false
+                                    final_predictions[met_probs .> met_threshold] .= true
+
+                                elseif i == config.num_models
+                                    ###Some weird syntax here because Julia doesn't like double indexing
+                                    ###Grab spots in the scan where the gates were both passing minimum quality control thresholds
+                                    ###and also have passed previous passes. Do this to ensure dimensional consistency with the
+                                    ###final prediction vector.
+                                    valid_idxs = indexer[init_idxer]
+                                    ###Grab locations in the prediction vector where this pass is being applied.
+                                    curr_preds = final_predictions[valid_idxs]
+                                    ###Final pass: just take the model's (majority vote) predictions for the class of the gates and we're done!
+                                    curr_preds[met_probs .>= met_threshold] .= true
+                                    curr_preds[met_probs .<  nmd_threshold] .= false
+                                    ###Reassign
+                                    final_predictions[valid_idxs] .= curr_preds
+                                else
+                                    ###Indexer has NOT yet been applied so index in to the existing predictions
+                                    valid_idxs = indexer[init_idxer]
+                                    ###Grab locations in the prediction vector where this pass is being applied.
+                                    curr_preds = final_predictions[valid_idxs]
+                                    curr_preds[met_probs .< nmd_threshold] .= false
+                                    curr_preds[met_probs .> met_threshold] .= true
+
+                                    final_predictions[valid_idxs] .= curr_preds
+
+                                end
+                                ###If this wasn't the last pass, write met_prob and mask for the next pass.
+                                ###The met_prob_pass_<i> write-back is required: subsequent passes
+                                ###(e.g. fore_mask Pass 2) consume met_prob_pass_<i> both as a plain
+                                ###conv variable and as the masked-conv met_prob field. Without it the
+                                ###masked-conv block is silently dropped, producing a too-narrow feature
+                                ###matrix and a BoundsError deep in the RF. Mirrors composite_prediction.
+                                if i < config.num_models
+                                    met_prob_field = Matrix{Union{Missing, Float32}}(missings(scan_dims))[:]
+                                    met_prob_field[indexer] .= met_probs
+                                    met_prob_field = reshape(met_prob_field, scan_dims)
+                                    _define_or_overwrite!(v, met_prob_name, met_prob_field;
+                                        attribs=Dict("Units" => "Probability", "Description" => "Meteorological probability from pass $(i)"),
+                                        fillval=config.FILL_VAL, verbose=false)
+
+                                    gates_of_interest = (met_probs .>= nmd_threshold) .& (met_probs .<= met_threshold)
+                                    new_mask = Matrix{Union{Missing, Float32}}(missings(scan_dims))[:]
+                                    ###If there are no gates of interest, write out the mask as ALL MISSINGS
+                                    ###Otherwise, fill in the gates of interest with 1's
+                                    if sum(gates_of_interest) != 0
+                                        @assert length(gates_of_interest) == sum(indexer)
+                                        indexer[indexer] .= gates_of_interest
+                                        new_mask[indexer] .= 1.
+                                    end
+                                    new_mask = reshape(new_mask, scan_dims)
+                                    _define_or_overwrite!(v, config.mask_names[i+1], new_mask;
+                                        attribs=Dict("Units" => "Bool", "Description" => "Gates between met prob thresholds"),
+                                        fillval=config.FILL_VAL)
+                                 end
+
+                                ###Save met_prob for the final pass too, so threshold sweeps /
+                                ###downstream tooling can read it back without recomputation.
+                                if i == config.num_models
+                                    met_prob_field = Matrix{Union{Missing, Float32}}(missings(scan_dims))[:]
+                                    met_prob_field[indexer] .= met_probs
+                                    met_prob_field = reshape(met_prob_field, scan_dims)
+                                    _define_or_overwrite!(v, met_prob_name, met_prob_field;
+                                        attribs=Dict("Units" => "Probability", "Description" => "Meteorological probability from pass $(i)"),
+                                        fillval=config.FILL_VAL, verbose=false)
+                                end
+                            else
+                                ###If the sum of the indexer is zero, we're done. There's nothing to predict upon.
+                                ###This will only happen on the first pass of the model, so we won't have to worry about actually making a prediction
+                                break
+                            end
 
 
-                ###Probably put the below into a separate function for code clarity
-                QC_scan(config, file, Vector{Bool}(final_predictions), Vector{Bool}(init_idxer))
+                        end # end pass loop
+
+
+                        ###Probably put the below into a separate function for code clarity
+                        QC_scan(config, v, Vector{Bool}(final_predictions), Vector{Bool}(init_idxer))
+                    end # end sweep loop
+                end # end NCDataset do-block
         end
     end
 

--- a/src/Ronin.jl
+++ b/src/Ronin.jl
@@ -4965,6 +4965,46 @@ module Ronin
 
 
 
+    ## Define a 2D field on an already-open NCDataset (or sweep subgroup),
+    ## overwriting in place if the variable already exists. No file open/close
+    ## — caller owns the handle. Use this inside loops that already hold the
+    ## file open, both to skip the open/close churn and (for CfRadial 2.0) to
+    ## write into the right /sweep_NNNN subgroup instead of the root.
+    function _define_or_overwrite!(target::NCDataset, fieldname::String, NEW_FIELD;
+                                    overwrite::Bool = true,
+                                    attribs::Dict = Dict(),
+                                    dim_names::Tuple = ("range", "time"),
+                                    verbose::Bool = true,
+                                    fillval::T = FILL_VAL,
+                                    context::String = "") where T <: Real
+        try
+            defVar(target, fieldname, NEW_FIELD, dim_names, fillvalue = fillval; attrib=attribs)
+        catch e
+            ## If the variable already exists and overwrite is set, simply
+            ## overwrite it (values + non-_FillValue attributes).
+            if isa(e, NCDatasets.NetCDFError) && e.msg == "NetCDF: String match to name in use" && overwrite
+                if verbose
+                    where_str = isempty(context) ? "" : " in $(context)"
+                    printstyled("$(fieldname) already exists$(where_str)... overwriting\n", color=:yellow)
+                end
+                target[fieldname][:,:] = NEW_FIELD
+                if attribs != Dict("" => "")
+                    for key in keys(attribs)
+                        key == "_FillValue" && continue
+                        target[fieldname].attrib[key] = attribs[key]
+                    end
+                end
+            else
+                throw(e)
+            end
+        end
+    end
+
+    ## SweepView convenience: write into the view's data subgroup (root for v1,
+    ## /sweep_NNNN for v2).
+    _define_or_overwrite!(v::SweepView, fieldname::String, NEW_FIELD; kwargs...) =
+        _define_or_overwrite!(v.data, fieldname, NEW_FIELD; kwargs...)
+
     """
         write_field(filepath::String, fieldname::String, NEW_FIELD, overwrite::Bool = true, attribs::Dict = Dict(), dim_names::Tuple = ("range", "time"), verbose::Bool=true)
         Helper function to write/overwrite a 2D field to a netCDF file
@@ -4976,8 +5016,6 @@ module Ronin
     function write_field(filepath::String, fieldname::String, NEW_FIELD; overwrite::Bool = true,
                 attribs::Dict = Dict(), dim_names::Tuple=("range", "time"), verbose::Bool=true, fillval::T = FILL_VAL) where T <: Real
 
-
-
         if ! isfile(filepath)
             ds = NCDataset(filepath, "c")
             close(ds)
@@ -4987,28 +5025,11 @@ module Ronin
             NCDataset(filepath, "a")
         end
 
-
         try
-            defVar(input_set, fieldname, NEW_FIELD, dim_names, fillvalue = fillval; attrib=attribs)
-        catch e
-            ###If the variable already exists and overwrite is set, simply overwrite it
-            if isa(e, NCDatasets.NetCDFError) && e.msg == "NetCDF: String match to name in use" && overwrite
-                if verbose
-                    printstyled("$(fieldname) already exists in $(filepath)... overwriting\n", color=:yellow)
-                end
-                input_set[fieldname][:,:] = NEW_FIELD
-
-                if attribs != Dict("" => "")
-                    for key in keys(attribs)
-                        if key == "_FillValue"
-                            continue
-                        end
-                        input_set[fieldname].attrib[key] = attribs[key]
-                    end
-                end
-            else
-                throw(e)
-            end
+            _define_or_overwrite!(input_set, fieldname, NEW_FIELD;
+                                   overwrite=overwrite, attribs=attribs,
+                                   dim_names=dim_names, verbose=verbose,
+                                   fillval=fillval, context=filepath)
         finally
             close(input_set)
         end

--- a/src/Ronin.jl
+++ b/src/Ronin.jl
@@ -216,6 +216,96 @@ module Ronin
         end
     end
 
+    ## Internal layout adapter. Presents a single CfRadial sweep — the root of a
+    ## v1 file or one /sweep_NNNN subgroup of a v2 file — with a uniform read /
+    ## write surface. Georeference variables (altitude, latitude, longitude, ...)
+    ## live at root in v1 and in a /georeference sub-sub-group in v2; the
+    ## `georef` field routes accesses accordingly. Not exported.
+    struct SweepView
+        data::NCDataset                       # v1: root; v2: /sweep_NNNN subgroup
+        georef::Union{NCDataset, Nothing}     # v1: nothing (georef vars live in `data`); v2: data.group["georeference"]
+        sweep_name::String                    # ""  for v1, "sweep_NNNN" for v2
+    end
+
+    Base.getindex(v::SweepView, name) = v.data[name]
+    Base.haskey(v::SweepView, name)   = haskey(v.data, name)
+    Base.keys(v::SweepView)           = keys(v.data)
+    dim_size(v::SweepView, name)      = v.data.dim[name]
+
+    ## Read a georeference variable (altitude / latitude / longitude / ...)
+    ## from the correct location for this layout: root for v1, /georeference
+    ## subgroup for v2.
+    function georef(v::SweepView, name)
+        if v.georef === nothing
+            return v.data[name]
+        else
+            return v.georef[name]
+        end
+    end
+
+    ## Defensive subgroup helpers — NCDatasets exposes child groups via
+    ## `f.group`, but some older versions or edge layouts can make naive
+    ## access throw; wrap in try/catch and return safe defaults.
+    function _has_subgroup(f::NCDataset, name::AbstractString)
+        try
+            return haskey(f.group, String(name))
+        catch
+            return false
+        end
+    end
+    function _subgroup_names(f::NCDataset)
+        try
+            return [String(g) for g in keys(f.group)]
+        catch
+            return String[]
+        end
+    end
+
+    ## Return one SweepView per QC-able sweep in the file.
+    ##   :ok          → single view at the file root (v1 single- or multi-sweep
+    ##                  concatenated; today's behavior).
+    ##   :cfradial2   → one view per /sweep_NNNN group, each pointing at its
+    ##                  /georeference subgroup if present.
+    ## Throws for :ragged / :unsupported; callers are expected to classify
+    ## with `_detect_cfrad_layout` and skip those layouts before calling here.
+    function sweep_views(f::NCDataset)
+        layout, _ = _detect_cfrad_layout(f)
+        if layout == :ok
+            return [SweepView(f, nothing, "")]
+        elseif layout == :cfradial2
+            ## Prefer the spec-canonical sweep_group_name(sweep) variable if
+            ## present; otherwise discover by scanning child groups.
+            names = String[]
+            if "sweep_group_name" in keys(f)
+                try
+                    for nm in f["sweep_group_name"][:]
+                        push!(names, String(nm))
+                    end
+                catch
+                    # fall through to subgroup scan
+                end
+            end
+            if isempty(names)
+                for s in _subgroup_names(f)
+                    startswith(s, "sweep_") && push!(names, s)
+                end
+                sort!(names)
+            end
+            views = SweepView[]
+            for nm in names
+                _has_subgroup(f, nm) || continue
+                sg = f.group[nm]
+                gr = _has_subgroup(sg, "georeference") ? sg.group["georeference"] : nothing
+                push!(views, SweepView(sg, gr, nm))
+            end
+            return views
+        else
+            throw(ArgumentError("sweep_views: unsupported CfRadial layout " *
+                                ":$(layout). Filter with _detect_cfrad_layout " *
+                                "before calling sweep_views."))
+        end
+    end
+
     """
         inspect_model_configuration(path::String; io::IO=stdout)
 

--- a/src/Ronin.jl
+++ b/src/Ronin.jl
@@ -1,12 +1,44 @@
 module Ronin
 
+    ## NCDatasets must come before the file includes so that the SweepView
+    ## struct (which carries `NCDataset` fields and is annotated on methods in
+    ## RoninFeatures.jl / RoninConvolutions.jl) is fully defined when those
+    ## files are evaluated. The rest of the heavy `using` block stays below.
+    using NCDatasets
+
+    ## Internal layout adapter. Presents a single CfRadial sweep — the root of
+    ## a v1 file or one /sweep_NNNN subgroup of a v2 file — with a uniform
+    ## read/write surface. Georeference variables (altitude, latitude,
+    ## longitude, ...) live at root in v1 and in a /georeference sub-sub-group
+    ## in v2; the `georef` field routes accesses accordingly. Not exported.
+    struct SweepView
+        data::NCDataset                       # v1: root; v2: /sweep_NNNN subgroup
+        georef::Union{NCDataset, Nothing}     # v1: nothing (georef vars live in `data`); v2: data.group["georeference"]
+        sweep_name::String                    # ""  for v1, "sweep_NNNN" for v2
+    end
+
+    Base.getindex(v::SweepView, name) = v.data[name]
+    Base.haskey(v::SweepView, name)   = haskey(v.data, name)
+    Base.keys(v::SweepView)           = keys(v.data)
+    dim_size(v::SweepView, name)      = v.data.dim[name]
+
+    ## Read a georeference variable (altitude / latitude / longitude / ...)
+    ## from the correct location for this layout: root for v1, /georeference
+    ## subgroup for v2.
+    function georef(v::SweepView, name)
+        if v.georef === nothing
+            return v.data[name]
+        else
+            return v.georef[name]
+        end
+    end
+
     include("./RoninFeatures.jl")
     include("./RoninConvolutions.jl")
     include("./Io.jl")
     include("./DecisionTree/DecisionTree.jl")
 
 
-    using NCDatasets
     using ImageFiltering
     using Statistics
     using Images
@@ -216,32 +248,9 @@ module Ronin
         end
     end
 
-    ## Internal layout adapter. Presents a single CfRadial sweep — the root of a
-    ## v1 file or one /sweep_NNNN subgroup of a v2 file — with a uniform read /
-    ## write surface. Georeference variables (altitude, latitude, longitude, ...)
-    ## live at root in v1 and in a /georeference sub-sub-group in v2; the
-    ## `georef` field routes accesses accordingly. Not exported.
-    struct SweepView
-        data::NCDataset                       # v1: root; v2: /sweep_NNNN subgroup
-        georef::Union{NCDataset, Nothing}     # v1: nothing (georef vars live in `data`); v2: data.group["georeference"]
-        sweep_name::String                    # ""  for v1, "sweep_NNNN" for v2
-    end
-
-    Base.getindex(v::SweepView, name) = v.data[name]
-    Base.haskey(v::SweepView, name)   = haskey(v.data, name)
-    Base.keys(v::SweepView)           = keys(v.data)
-    dim_size(v::SweepView, name)      = v.data.dim[name]
-
-    ## Read a georeference variable (altitude / latitude / longitude / ...)
-    ## from the correct location for this layout: root for v1, /georeference
-    ## subgroup for v2.
-    function georef(v::SweepView, name)
-        if v.georef === nothing
-            return v.data[name]
-        else
-            return v.georef[name]
-        end
-    end
+    ## SweepView struct + getindex/haskey/keys/dim_size/georef are defined at
+    ## the top of the module (above the includes), so methods dispatching on
+    ## SweepView in RoninFeatures.jl / RoninConvolutions.jl resolve correctly.
 
     ## Defensive subgroup helpers — NCDatasets exposes child groups via
     ## `f.group`, but some older versions or edge layouts can make naive
@@ -1432,19 +1441,23 @@ module Ronin
 
     Convolution-mode equivalent of `process_single_file`. Computes convolution features
     for a single sweep, builds the validity mask and INDEXER, and returns (X, Y, INDEXER).
+
+    Operates on a `SweepView` so CfRadial 2.0 sweep subgroups work the same as
+    v1 root datasets. The `NCDataset` method is a back-compat shim that wraps
+    the dataset as a v1 root view.
     """
-    function process_single_file_conv(cfrad::NCDataset, config::ModelConfig, kernel_bank::Vector{ConvolutionKernel};
+    function process_single_file_conv(v::SweepView, config::ModelConfig, kernel_bank::Vector{ConvolutionKernel};
                                        feature_mask::AbstractMatrix{Bool}=placeholder_mask, mask_features::Bool=false)
 
-        cfrad_dims = (cfrad.dim["range"], cfrad.dim["time"])
+        cfrad_dims = (dim_size(v, "range"), dim_size(v, "time"))
         ngates = cfrad_dims[1] * cfrad_dims[2]
 
         # Build INDEXER: valid where remove_var is non-missing
-        VT = cfrad[config.remove_var][:]
+        VT = v[config.remove_var][:]
         INDEXER = [!ismissing(x) for x in VT]
 
         if length(VT) != ngates
-            fname = try; string(NCDatasets.path(cfrad)); catch; ""; end
+            fname = try; string(NCDatasets.path(v.data)); catch; ""; end
             throw(DimensionMismatch(
                 "remove_var '$(config.remove_var)' has $(length(VT)) gates but " *
                 "the sweep grid (range × time = $(cfrad_dims[1]) × $(cfrad_dims[2])) " *
@@ -1453,7 +1466,7 @@ module Ronin
 
         if mask_features
             if length(feature_mask) != ngates
-                fname = try; string(NCDatasets.path(cfrad)); catch; ""; end
+                fname = try; string(NCDatasets.path(v.data)); catch; ""; end
                 throw(DimensionMismatch(
                     "QC feature mask has $(length(feature_mask)) gates but the " *
                     "sweep grid (range × time = $(cfrad_dims[1]) × $(cfrad_dims[2])) " *
@@ -1466,13 +1479,13 @@ module Ronin
         # PGG thresholding
         PGG = nothing
         if config.REMOVE_HIGH_PGG
-            PGG = [ismissing(x) || isnan(x) ? Float32(FILL_VAL) : Float32(x) for x in calc_pgg(cfrad)[:]]
+            PGG = [ismissing(x) || isnan(x) ? Float32(FILL_VAL) : Float32(x) for x in calc_pgg(v)[:]]
             INDEXER[INDEXER] = [x >= config.PGG_THRESHOLD ? false : true for x in PGG[INDEXER]]
         end
 
         # Signal quality thresholding
         if config.REMOVE_LOW_SIG_QUALITY
-            SIG = [ismissing(x) || isnan(x) ? Float32(FILL_VAL) : Float32(x) for x in calc_sig(cfrad, config.SIG_QUALITY_VAR)[:]]
+            SIG = [ismissing(x) || isnan(x) ? Float32(FILL_VAL) : Float32(x) for x in calc_sig(v, config.SIG_QUALITY_VAR)[:]]
             INDEXER[INDEXER] = [x <= config.SIG_QUALITY_THRESHOLD ? false : true for x in SIG[INDEXER]]
         end
 
@@ -1488,13 +1501,13 @@ module Ronin
         if !isempty(config.masked_conv_variables) && config.masked_conv_met_prob_field != ""
             masked_conv_kb = build_filtered_kernel_bank(config.masked_conv_kernel_types,
                                                          config.masked_conv_kernel_sizes)
-            if config.masked_conv_met_prob_field in keys(cfrad)
-                mp_raw = load_conv_variable(cfrad, config.masked_conv_met_prob_field,
+            if config.masked_conv_met_prob_field in keys(v)
+                mp_raw = load_conv_variable(v, config.masked_conv_met_prob_field,
                                              valid_mask, config.SIG_QUALITY_VAR)
                 mp_f32 = Matrix{Float32}(undef, cfrad_dims...)
                 for j in 1:cfrad_dims[2], i in 1:cfrad_dims[1]
-                    v = mp_raw[i, j]
-                    mp_f32[i, j] = (ismissing(v) || (v isa AbstractFloat && isnan(v))) ? 0.0f0 : Float32(v)
+                    val = mp_raw[i, j]
+                    mp_f32[i, j] = (ismissing(val) || (val isa AbstractFloat && isnan(val))) ? 0.0f0 : Float32(val)
                 end
                 met_prob_mask = mp_f32 .>= config.masked_conv_threshold
             else
@@ -1503,7 +1516,7 @@ module Ronin
         end
 
         # Compute convolution features
-        X_full, feature_names = compute_convolution_features(cfrad, conv_vars, kernel_bank, valid_mask, config.SIG_QUALITY_VAR;
+        X_full, feature_names = compute_convolution_features(v, conv_vars, kernel_bank, valid_mask, config.SIG_QUALITY_VAR;
             masked_conv_variables = config.masked_conv_variables,
             masked_conv_kernel_bank = masked_conv_kb,
             masked_conv_threshold = config.masked_conv_threshold,
@@ -1519,14 +1532,21 @@ module Ronin
 
         # Build Y if interactive QC
         if config.HAS_INTERACTIVE_QC
-            VG = cfrad[config.QC_var][:][INDEXER]
-            VV = cfrad[config.remove_var][:][INDEXER]
+            VG = v[config.QC_var][:][INDEXER]
+            VV = v[config.remove_var][:][INDEXER]
             Y = reshape([ismissing(x) ? 0 : 1 for x in VG .- VV][:], (:, 1))
             return (X, Y, INDEXER, feature_names)
         else
             return (X, false, INDEXER, feature_names)
         end
     end
+
+    ## Back-compat shim: NCDataset → wrap as v1 root SweepView and delegate.
+    process_single_file_conv(cfrad::NCDataset, config::ModelConfig,
+                             kernel_bank::Vector{ConvolutionKernel};
+                             kwargs...) =
+        process_single_file_conv(SweepView(cfrad, nothing, ""), config,
+                                 kernel_bank; kwargs...)
 
 
     """

--- a/src/Ronin.jl
+++ b/src/Ronin.jl
@@ -1294,7 +1294,23 @@ module Ronin
         VT = cfrad[config.remove_var][:]
         INDEXER = [!ismissing(x) for x in VT]
 
+        if length(VT) != ngates
+            fname = try; string(NCDatasets.path(cfrad)); catch; ""; end
+            throw(DimensionMismatch(
+                "remove_var '$(config.remove_var)' has $(length(VT)) gates but " *
+                "the sweep grid (range × time = $(cfrad_dims[1]) × $(cfrad_dims[2])) " *
+                "has $ngates" * (isempty(fname) ? "" : " in file $fname") * "."))
+        end
+
         if mask_features
+            if length(feature_mask) != ngates
+                fname = try; string(NCDatasets.path(cfrad)); catch; ""; end
+                throw(DimensionMismatch(
+                    "QC feature mask has $(length(feature_mask)) gates but the " *
+                    "sweep grid (range × time = $(cfrad_dims[1]) × $(cfrad_dims[2])) " *
+                    "has $ngates" * (isempty(fname) ? "" : " in file $fname") *
+                    ". The saved mask field does not match this file's dimensions."))
+            end
             INDEXER = [INDEXER[i] ? maskval : false for (i, maskval) in enumerate(feature_mask[:])]
         end
 
@@ -4358,15 +4374,28 @@ module Ronin
         ###Probably can section this off into a different function later since it's also reused in the streaming/realtime version
         for file in files
             curr_starttime = time()
-                ###Get dimensions
+                ###Get dimensions, and detect the CfRadial contiguous ragged-array
+                ###representation (n_points / ray_start_index / ray_n_gates), which
+                ###Ronin's gridded (range × time) feature path cannot ingest.
+                ###Skip ragged files with a clear warning rather than crashing.
 
-            scan_dims = redirect_stdout(devnull) do
+            is_ragged, scan_dims = redirect_stdout(devnull) do
 
-                scan_dims = NCDataset(file) do f
-                    (dimsize(f["range"]).range, dimsize(f["time"]).time)
+                NCDataset(file) do f
+                    ragged = haskey(f.dim, "n_points") ||
+                             ("ray_n_gates" in keys(f)) ||
+                             ("ray_start_index" in keys(f))
+                    (ragged, (dimsize(f["range"]).range, dimsize(f["time"]).time))
                 end
+            end
 
-                scan_dims
+            if is_ragged
+                printstyled("WARNING: Skipping ragged-array CfRadial (n_points " *
+                            "representation), unsupported by the gridded prediction " *
+                            "path: $(file)\n         Convert to a gridded CfRadial " *
+                            "(e.g. RadxConvert -const_ngate) to process this file.\n",
+                            color=:yellow)
+                continue
             end
 
             ###init_idxer contains the gates that pass the first-level QC checks (NCP, PGG) + inital mask
@@ -5394,9 +5423,25 @@ module Ronin
                 if isdir(file)
                     continue
                 end
-                ###Get dimensions
-                scan_dims = NCDataset(file) do f
-                    (dimsize(f["range"]).range, dimsize(f["time"]).time)
+                ###Get dimensions, and detect the CfRadial contiguous ragged-array
+                ###representation (n_points / ray_start_index / ray_n_gates), which
+                ###Ronin's gridded (range × time) feature path cannot ingest.
+                ###Skip ragged files with a clear warning rather than crashing the
+                ###whole volume/day chunk.
+                is_ragged, scan_dims = NCDataset(file) do f
+                    ragged = haskey(f.dim, "n_points") ||
+                             ("ray_n_gates" in keys(f)) ||
+                             ("ray_start_index" in keys(f))
+                    (ragged, (dimsize(f["range"]).range, dimsize(f["time"]).time))
+                end
+
+                if is_ragged
+                    printstyled("WARNING: Skipping ragged-array CfRadial (n_points " *
+                                "representation), unsupported by the gridded QC path: " *
+                                "$(file)\n         Convert to a gridded CfRadial " *
+                                "(e.g. RadxConvert -const_ngate) to QC this file.\n",
+                                color=:yellow)
+                    continue
                 end
 
                 ###init_idxer contains the gates that pass the first-level QC checks (NCP, PGG) + inital mask

--- a/src/RoninConvolutions.jl
+++ b/src/RoninConvolutions.jl
@@ -59,7 +59,17 @@ end
     build_filtered_kernel_bank(kernel_types::Vector{String}, kernel_sizes::Vector{Int})
 
 Build a kernel bank from the Cartesian product of `kernel_types` and `kernel_sizes`.
-Invalid combinations (e.g., laplacian at 5x5, gaussian at 3x3) are skipped with a warning.
+
+Some kernel types are size-restricted **by design** — `laplacian`,
+`sobel_range`, and `sobel_azi` are only the canonical 3x3 stencils, and
+`gaussian` is only built at sizes >= 5 (a 3x3 Gaussian with the default sigma
+is degenerate and redundant with `mean_3x3`). Those Cartesian-product
+combinations are skipped **silently** here: callers pass arrays of sizes and
+expect to get the valid subset, so a per-call warning would be log spam
+(this runs once per scan per pass). The skipped set is reported once at the
+start of training via [`masked_conv_skipped_combos`]; it is deterministic
+from config, never data-dependent. An unknown kernel type is still a hard
+error.
 
 Supported kernel types: "mean", "gaussian", "laplacian", "sobel_range", "sobel_azi".
 """
@@ -73,33 +83,56 @@ function build_filtered_kernel_bank(kernel_types::Vector{String}, kernel_sizes::
             elseif ktype == "laplacian"
                 if k == 3
                     push!(bank, ConvolutionKernel("laplacian_3x3", Float32[0 1 0; 1 -4 1; 0 1 0]))
-                else
-                    @warn "Laplacian only supported at 3x3, skipping $(k)x$(k)"
                 end
+                # else: size-restricted by design — see masked_conv_skipped_combos
             elseif ktype == "sobel_range"
                 if k == 3
                     push!(bank, ConvolutionKernel("sobel_range_3x3", Float32[-1 -2 -1; 0 0 0; 1 2 1]))
-                else
-                    @warn "Sobel range only supported at 3x3, skipping $(k)x$(k)"
                 end
+                # else: size-restricted by design — see masked_conv_skipped_combos
             elseif ktype == "sobel_azi"
                 if k == 3
                     push!(bank, ConvolutionKernel("sobel_azi_3x3", Float32[-1 0 1; -2 0 2; -1 0 1]))
-                else
-                    @warn "Sobel azi only supported at 3x3, skipping $(k)x$(k)"
                 end
+                # else: size-restricted by design — see masked_conv_skipped_combos
             elseif ktype == "gaussian"
                 if k >= 5
                     push!(bank, ConvolutionKernel("gaussian_$(k)x$(k)", _gaussian_kernel(k)))
-                else
-                    @warn "Gaussian only supported at sizes >= 5, skipping $(k)x$(k)"
                 end
+                # else: size-restricted by design — see masked_conv_skipped_combos
             else
                 error("Unknown kernel type: $(ktype). Supported: mean, gaussian, laplacian, sobel_range, sobel_azi")
             end
         end
     end
     return bank
+end
+
+"""
+    masked_conv_skipped_combos(kernel_types, kernel_sizes) -> Vector{Tuple{String,Int}}
+
+Return the `(kernel_type, size)` pairs that `build_filtered_kernel_bank` skips
+**by design** because that kernel type is size-restricted:
+
+- `laplacian`, `sobel_range`, `sobel_azi` exist only at 3x3
+- `gaussian` exists only at sizes >= 5
+
+This is purely a reporting helper so training can surface the skipped set once
+(it is fully determined by config, not by data). The size rules below MUST be
+kept in sync with `build_filtered_kernel_bank` above. Unknown kernel types are
+intentionally not flagged here — `build_filtered_kernel_bank` errors on them.
+"""
+function masked_conv_skipped_combos(kernel_types::Vector{String}, kernel_sizes::Vector{Int})
+    skipped = Tuple{String, Int}[]
+    for ktype in kernel_types
+        for k in kernel_sizes
+            if (ktype in ("laplacian", "sobel_range", "sobel_azi") && k != 3) ||
+               (ktype == "gaussian" && k < 5)
+                push!(skipped, (ktype, k))
+            end
+        end
+    end
+    return skipped
 end
 
 """

--- a/src/RoninFeatures.jl
+++ b/src/RoninFeatures.jl
@@ -94,7 +94,22 @@ end
 
 
 """
-Function to calculate the height of a given gate 
+    airborne_ht(elevation_angle::Float32, antenna_range::Float32, aircraft_height::Float32)
+
+Earth-curvature-corrected height of a radar gate above mean sea level for an
+airborne (or elevated) platform.
+
+# Arguments
+- `elevation_angle`: beam elevation angle in **degrees** (positive above the horizon).
+- `antenna_range`: slant range from the antenna to the gate in **metres**.
+- `aircraft_height`: platform height above mean sea level in **metres**.
+
+# Returns
+The gate height in **kilometres**, accounting for the curvature of the Earth
+(`Ronin.EarthRadiusKm`) using the standard 4/3-Earth-style geometric relation.
+
+This is the per-gate kernel behind the `AHT` derived feature; `calc_aht`
+applies it across a full sweep grid.
 """
 function airborne_ht(elevation_angle::Float32, antenna_range::Float32, aircraft_height::Float32)
     ##Initial heights are in meters, convert to km 
@@ -106,6 +121,30 @@ function airborne_ht(elevation_angle::Float32, antenna_range::Float32, aircraft_
 end 
 
 
+"""
+    prob_groundgate(elevation_angle, antenna_range, aircraft_height, azimuth)
+
+Geometric probability that a radar gate is contaminated by the ground (the `PGG`
+derived feature, per-gate kernel).
+
+Uses the beam/ground intersection geometry of Testud et al. to decide whether the
+beam can physically reach the surface, then attenuates by a Gaussian beam pattern
+(half-power beamwidth `Ronin.beamwidth`) of the offset between the beam axis and
+the ground-grazing elevation.
+
+# Arguments
+- `elevation_angle`: beam elevation angle in **degrees** (negative points toward the ground).
+- `antenna_range`: slant range to the gate in **metres**.
+- `aircraft_height`: platform height above the surface in **metres**.
+- `azimuth`: beam azimuth in **degrees**.
+
+# Returns
+A probability in `[0, 1]` (`1` = certainly ground), or `missing` if any input is
+`missing`. Returns `0` early when the gate geometrically cannot intersect the
+ground (range shorter than platform height, or elevation at/above the horizon).
+
+`calc_pgg` applies this across a full sweep grid.
+"""
 function prob_groundgate(elevation_angle, antenna_range, aircraft_height, azimuth)
 
     if (ismissing(elevation_angle) || ismissing(antenna_range) || ismissing(aircraft_height) || ismissing(azimuth)) 
@@ -147,7 +186,24 @@ function prob_groundgate(elevation_angle, antenna_range, aircraft_height, azimut
 end 
 
 
-##Calculate the windowed standard deviation of a given variablevariable 
+"""
+    calc_std(var::AbstractMatrix; weights = std_weights, window = std_window)
+
+Windowed standard deviation of a radar field — the `STD(var)` spatial reducer
+used by both the convolution and legacy hand-tuned feature modes.
+
+For each gate, the standard deviation is taken over the surrounding `window`
+neighbourhood (default `Ronin.std_window`) after element-wise multiplication by
+`weights` (default `Ronin.std_weights`). Gates whose value is `missing` are
+excluded from each window; a window that is entirely `missing` yields
+`Ronin.FILL_VAL`. Borders are padded with `missing`.
+
+The `Union{Missing, Float32}` method preserves missing-aware reduction; the
+generic-matrix method honours the global `REPLACE_MISSING_WITH_FILL` flag and
+substitutes `FILL_VAL` for missing inputs before reducing.
+
+Returns a `Float32` matrix the same size as `var`.
+"""
 function calc_std(var::AbstractMatrix{Union{Missing, Float32}}; weights = std_weights, window = std_window)
 
     rows, cols = size(var)
@@ -168,6 +224,21 @@ function calc_std(var::AbstractMatrix{}; weights = std_weights, window = std_win
     @inbounds mapwindow((x) -> _weighted_func(x, weights, missing_std), var, window, border=Fill(missing))
 end 
 
+"""
+    calc_avg(var::Matrix; weights = avg_weights, window = avg_window)
+
+Windowed mean of a radar field — the `AVG(var)` spatial reducer used by both the
+convolution and legacy hand-tuned feature modes.
+
+For each gate, the mean is taken over the surrounding `window` neighbourhood
+(default `Ronin.avg_window`) after element-wise multiplication by `weights`
+(default `Ronin.avg_weights`). Gates whose value is `missing` are excluded from
+each window; a window that is entirely `missing` yields `Ronin.FILL_VAL`.
+Borders are padded with `missing`. The global `REPLACE_MISSING_WITH_FILL` flag,
+when set, substitutes `FILL_VAL` for missing inputs before reducing.
+
+Returns a `Float32` matrix the same size as `var`.
+"""
 function calc_avg(var::Matrix{Union{Missing, Float32}}; weights = avg_weights, window = avg_window)
 
     if ( REPLACE_MISSING_WITH_FILL)
@@ -230,6 +301,22 @@ function calc_elv(cfrad::NCDataset)
 
 end 
 
+"""
+    get_num_tasks(params_file; delimeter = ",")
+
+Count the number of predictor tasks declared in a legacy hand-tuned-mode
+configuration file.
+
+`params_file` is a path to a config file (e.g. `config.txt`) where each
+non-comment line lists `delimeter`-separated predictor tasks such as
+`STD(VEL),AVG(ZZ),PGG`. Lines beginning with `#` are treated as comments and
+skipped; empty tokens are not counted.
+
+Returns the total number of tasks as an `Int`. This is legacy-mode
+(`task_mode = ""`) machinery only — convolution mode derives its own feature
+count via `get_convolution_feature_count`. A second method,
+`get_num_tasks(tasks::Vector{String})`, simply returns `length(tasks)`.
+"""
 function get_num_tasks(params_file; delimeter = ",")
 
     tasks = readlines(params_file)

--- a/src/RoninFeatures.jl
+++ b/src/RoninFeatures.jl
@@ -502,7 +502,7 @@ get_task_params(tasks::Vector{String}, variablelist) = tasks
             values in `feature_mask` are false. 
 
 """
-function process_single_file(cfrad::NCDataset, argfile_path::String; HAS_INTERACTIVE_QC::Bool = false,
+function process_single_file(v::SweepView, argfile_path::String; HAS_INTERACTIVE_QC::Bool = false,
     REMOVE_LOW_SIG_QUALITY::Bool = false, SIG_QUALITY_THRESHOLD::Float32 = .2f0, SIG_QUALITY_VAR = "NCP",
     REMOVE_HIGH_PGG::Bool = false, PGG_THRESHOLD::Float32 = 1.f0,
      QC_variable::String = "VG", remove_variable::String = "VV", replace_missing::Bool=false,
@@ -517,15 +517,41 @@ function process_single_file(cfrad::NCDataset, argfile_path::String; HAS_INTERAC
         REMOVE_LOW_SIG_QUALITY = REMOVE_LOW_NCP
     end
 
-    valid_vars = keys(cfrad)
+    valid_vars = keys(v)
     curr_tasks = get_task_params(argfile_path, valid_vars)
 
-    process_single_file(cfrad, curr_tasks; HAS_INTERACTIVE_QC=HAS_INTERACTIVE_QC, REMOVE_LOW_SIG_QUALITY=REMOVE_LOW_SIG_QUALITY,
+    process_single_file(v, curr_tasks; HAS_INTERACTIVE_QC=HAS_INTERACTIVE_QC, REMOVE_LOW_SIG_QUALITY=REMOVE_LOW_SIG_QUALITY,
                         SIG_QUALITY_THRESHOLD=SIG_QUALITY_THRESHOLD, SIG_QUALITY_VAR=SIG_QUALITY_VAR,
                         REMOVE_HIGH_PGG = REMOVE_HIGH_PGG, PGG_THRESHOLD=PGG_THRESHOLD, QC_variable = QC_variable,
                         remove_variable = remove_variable, replace_missing = replace_missing,
                         mask_features = mask_features, feature_mask =feature_mask, weight_matrixes = weight_matrixes)
 
+end
+
+## Back-compat shim: NCDataset → wrap as v1 root SweepView and delegate.
+## Kwargs are spelled out (rather than slurped via kwargs...) so that
+## `Base.kwarg_decl` introspection — used by the v1.1.0 deprecation tests —
+## continues to see REMOVE_LOW_NCP / REMOVE_LOW_SIG_QUALITY explicitly.
+function process_single_file(cfrad::NCDataset, argfile_path::String;
+    HAS_INTERACTIVE_QC::Bool = false,
+    REMOVE_LOW_SIG_QUALITY::Bool = false, SIG_QUALITY_THRESHOLD::Float32 = .2f0, SIG_QUALITY_VAR = "NCP",
+    REMOVE_HIGH_PGG::Bool = false, PGG_THRESHOLD::Float32 = 1.f0,
+    QC_variable::String = "VG", remove_variable::String = "VV", replace_missing::Bool = false,
+    mask_features::Bool = false, feature_mask::Matrix{Bool} = [true true ; false false;],
+    weight_matrixes::Vector{Matrix{Union{Missing, Float32}}} = [Matrix{Union{Missing, Float32}}(undef, 0, 0)],
+    REMOVE_LOW_NCP = nothing)
+
+    process_single_file(SweepView(cfrad, nothing, ""), argfile_path;
+        HAS_INTERACTIVE_QC = HAS_INTERACTIVE_QC,
+        REMOVE_LOW_SIG_QUALITY = REMOVE_LOW_SIG_QUALITY,
+        SIG_QUALITY_THRESHOLD = SIG_QUALITY_THRESHOLD,
+        SIG_QUALITY_VAR = SIG_QUALITY_VAR,
+        REMOVE_HIGH_PGG = REMOVE_HIGH_PGG, PGG_THRESHOLD = PGG_THRESHOLD,
+        QC_variable = QC_variable, remove_variable = remove_variable,
+        replace_missing = replace_missing,
+        mask_features = mask_features, feature_mask = feature_mask,
+        weight_matrixes = weight_matrixes,
+        REMOVE_LOW_NCP = REMOVE_LOW_NCP)
 end
 
 

--- a/src/RoninFeatures.jl
+++ b/src/RoninFeatures.jl
@@ -20,10 +20,14 @@ function missing_avg(data)
     mean(skipmissing(data))
 end 
 
-### Returns flattened version of signal quality variable
-function calc_sig(cfrad::NCDataset, varname::String)
-    return(cfrad[varname][:]) 
-end 
+### Returns flattened version of signal quality variable. Operates on a
+### SweepView (root for CfRadial 1.x, /sweep_NNNN subgroup for CfRadial 2.0);
+### the NCDataset method is a back-compat shim that treats the dataset as a
+### v1 root view.
+function calc_sig(v::SweepView, varname::String)
+    return(v[varname][:])
+end
+calc_sig(cfrad::NCDataset, varname::String) = calc_sig(SweepView(cfrad, nothing, ""), varname)
 
 # ##Returns flattened version of NCP 
 # function calc_ncp(data::NCDataset)
@@ -50,15 +54,17 @@ end
 #     error("Could not find NCP_L2, SQI_L2, NCP, or SQI in Dataset")
 # end
 
-function calc_rng(data::NCDataset)
-    return(repeat(data["range"][:], 1, length(data["time"])))
-end 
+function calc_rng(v::SweepView)
+    return(repeat(v["range"][:], 1, length(v["time"])))
+end
+calc_rng(data::NCDataset) = calc_rng(SweepView(data, nothing, ""))
 
-function calc_nrg(data::NCDataset)
-    rngs = calc_rng(data)
-    alts = repeat(transpose(data["altitude"][:]), length(data["range"]), 1)
+function calc_nrg(v::SweepView)
+    rngs = calc_rng(v)
+    alts = repeat(transpose(georef(v, "altitude")[:]), length(v["range"]), 1)
     return(rngs ./ alts)
-end 
+end
+calc_nrg(data::NCDataset) = calc_nrg(SweepView(data, nothing, ""))
 
 
 function _weighted_func(var, weights, func)
@@ -259,47 +265,50 @@ function calc_avg(var::Matrix{}; weights = avg_weights, window = avg_window)
     @inbounds mapwindow((x) -> _weighted_func(x, weights, missing_avg), var, window, border=Fill(missing))
 end
 
-function calc_pgg(cfrad::NCDataset)
+function calc_pgg(v::SweepView)
 
-    num_times = length(cfrad["time"])
-    num_ranges = length(cfrad["range"])
+    num_times = length(v["time"])
+    num_ranges = length(v["range"])
 
-    ranges = repeat(cfrad["range"][:], 1, num_times)
+    ranges = repeat(v["range"][:], 1, num_times)
     ##Height, elevation, and azimuth will be the same for every ray
-    heights = repeat(transpose(cfrad["altitude"][:]), num_ranges, 1)
-    elevs = repeat(transpose(cfrad["elevation"][:]), num_ranges, 1)
-    azimuths = repeat(transpose(cfrad["azimuth"][:]), num_ranges, 1)
-    
-    ##This would return 
+    heights = repeat(transpose(georef(v, "altitude")[:]), num_ranges, 1)
+    elevs = repeat(transpose(v["elevation"][:]), num_ranges, 1)
+    azimuths = repeat(transpose(v["azimuth"][:]), num_ranges, 1)
+
+    ##This would return
     @inbounds return(map((w,x,y,z) -> prob_groundgate(w,x,y,z), elevs, ranges, heights, azimuths))
-end 
+end
+calc_pgg(cfrad::NCDataset) = calc_pgg(SweepView(cfrad, nothing, ""))
 
 """
-Function used for calculating grid of radar gate heights. 
+Function used for calculating grid of radar gate heights.
 """
-function calc_aht(cfrad::NCDataset)
+function calc_aht(v::SweepView)
 
-    num_times = length(cfrad["time"])
-    num_ranges = length(cfrad["range"])
-    
-    elevs = repeat(transpose(cfrad["elevation"][:]), num_ranges, 1)
-    ranges = repeat(cfrad["range"][:], 1, num_times)
-    heights = repeat(transpose(cfrad["altitude"][:]), num_ranges, 1)
+    num_times = length(v["time"])
+    num_ranges = length(v["range"])
+
+    elevs = repeat(transpose(v["elevation"][:]), num_ranges, 1)
+    ranges = repeat(v["range"][:], 1, num_times)
+    heights = repeat(transpose(georef(v, "altitude")[:]), num_ranges, 1)
 
     @inbounds return(map((x,y,z) -> airborne_ht(Float32(x),Float32(y),Float32(z)), elevs, ranges, heights))
 
-end 
+end
+calc_aht(cfrad::NCDataset) = calc_aht(SweepView(cfrad, nothing, ""))
 
 """
 Function used for mapping elevation angle onto a grid
 """ 
-function calc_elv(cfrad::NCDataset)
+function calc_elv(v::SweepView)
 
-    num_times = length(cfrad["time"])
-    num_ranges = length(cfrad["range"])
-    repeat(transpose(cfrad["elevation"][:]), num_ranges, 1)
+    num_times = length(v["time"])
+    num_ranges = length(v["range"])
+    repeat(transpose(v["elevation"][:]), num_ranges, 1)
 
-end 
+end
+calc_elv(cfrad::NCDataset) = calc_elv(SweepView(cfrad, nothing, ""))
 
 """
     get_num_tasks(params_file; delimeter = ",")
@@ -609,7 +618,7 @@ For spatial parameters, whether or not to replace `missings` values with `FILL_V
                 where in the scan features valid data and where does not. Will also contain `false` where 
                 values in `feature_mask` are false. 
 """
-function process_single_file(cfrad::NCDataset, tasks::Vector{String};
+function process_single_file(v::SweepView, tasks::Vector{String};
     HAS_INTERACTIVE_QC::Bool = false,
     REMOVE_LOW_SIG_QUALITY::Bool = false, SIG_QUALITY_THRESHOLD::Float32 = .2f0, SIG_QUALITY_VAR = "NCP",
     REMOVE_HIGH_PGG::Bool = false, PGG_THRESHOLD::Float32 = 1.f0,
@@ -624,22 +633,24 @@ function process_single_file(cfrad::NCDataset, tasks::Vector{String};
         REMOVE_LOW_SIG_QUALITY = REMOVE_LOW_NCP
     end
 
-    cfrad_dims = (cfrad.dim["range"], cfrad.dim["time"])
+    nrange = dim_size(v, "range")
+    ntime  = dim_size(v, "time")
+    cfrad_dims = (nrange, ntime)
     #println("\r\nDIMENSIONS: $(cfrad_dims[1]) times x $(cfrad_dims[2]) ranges\n")
-    
+
     if replace_missing
-        global REPLACE_MISSING_WITH_FILL = true 
-    else 
-        global REPLACE_MISSING_WITH_FILL = false 
-    end 
+        global REPLACE_MISSING_WITH_FILL = true
+    else
+        global REPLACE_MISSING_WITH_FILL = false
+    end
 
-    valid_vars = keys(cfrad) 
-    ###Features array 
-    X = Matrix{Float32}(undef,cfrad.dim["time"] * cfrad.dim["range"], length(tasks))
+    valid_vars = keys(v)
+    ###Features array
+    X = Matrix{Float32}(undef, ntime * nrange, length(tasks))
 
-    ###Array to hold PGG for indexing  
-    PGG = Matrix{Float32}(undef, cfrad.dim["time"]*cfrad.dim["range"], 1)
-    SIG = Matrix{Float32}(undef, cfrad.dim["time"]*cfrad.dim["range"], 1)
+    ###Array to hold PGG for indexing
+    PGG = Matrix{Float32}(undef, ntime * nrange, 1)
+    SIG = Matrix{Float32}(undef, ntime * nrange, 1)
 
     PGG_Completed_Flag = false 
     SIG_Completed_Flag = false 
@@ -687,19 +698,19 @@ function process_single_file(cfrad::NCDataset, tasks::Vector{String};
                 window_size = size(weight_matrix)
             end 
 
-            currdat = cfrad[var][:,:]
+            currdat = v[var][:,:]
 
             if mask_features
-                ##Set invalid data to missing for spatial parameter calculations. This way, they 
-                ##will be ignored. 
-                currdat[.! feature_mask] .= missing 
+                ##Set invalid data to missing for spatial parameter calculations. This way, they
+                ##will be ignored.
+                currdat[.! feature_mask] .= missing
 
                 raw = @eval $func($currdat)[:]
-                
+
             else
                 #raw = @eval slide_window(currdat, weight_matrix, $func)[:]
-                raw = @eval $func($cfrad[$var][:,:]; weights=$weight_matrix, window = $window_size )[:]
-            end 
+                raw = @eval $func($v[$var][:,:]; weights=$weight_matrix, window = $window_size )[:]
+            end
 
             filled = [ismissing(x) || isnan(x) ? Float32(FILL_VAL) : Float32(x) for x in raw]
         
@@ -718,12 +729,12 @@ function process_single_file(cfrad::NCDataset, tasks::Vector{String};
             ###bona-fide derived parameter but wiht the way the files are setup wanted to
             ###include it in the list of derived parameters. 
             if (task == "SIG")
-                SIG = calc_sig(cfrad, SIG_QUALITY_VAR)
+                SIG = calc_sig(v, SIG_QUALITY_VAR)
                 SIG_Completed_Flag = true
                 X[:, i] = [ismissing(x) || isnan(x) ? Float32(FILL_VAL) : Float32(x) for x in SIG[:]]
             else
                 func = Symbol(func_prefix * lowercase(task))
-                raw = @eval $func($cfrad)[:]
+                raw = @eval $func($v)[:]
                 X[:, i] = [ismissing(x) || isnan(x) ? Float32(FILL_VAL) : Float32(x) for x in raw]
 
                 if (task == "PGG")
@@ -735,11 +746,11 @@ function process_single_file(cfrad::NCDataset, tasks::Vector{String};
 
             calc_length = time() - startTime
         ###Otherwise it's just a variable from the cfrad 
-        else 
-            startTime = time() 
-            X[:, i] = [ismissing(x) || isnan(x) ? Float32(FILL_VAL) : Float32(x) for x in cfrad[task][:]]
+        else
+            startTime = time()
+            X[:, i] = [ismissing(x) || isnan(x) ? Float32(FILL_VAL) : Float32(x) for x in v[task][:]]
             calc_length = time() - startTime
-        end 
+        end
     end
 
 
@@ -751,7 +762,7 @@ function process_single_file(cfrad::NCDataset, tasks::Vector{String};
 
     starttime = time() 
 
-    VT = cfrad[remove_variable][:]
+    VT = v[remove_variable][:]
     INDEXER = [ismissing(x) for x in VT]
     ##Initial gates to focus on 
   
@@ -780,12 +791,12 @@ function process_single_file(cfrad::NCDataset, tasks::Vector{String};
     	println("DATAPOINTS BEFORE SIGNAL QUALITY THRESHOLDING APPLIED: $(sum(INDEXER))") 
         ###Remove data that does not equal or exceed minimum NCP threshold 
         ###Only need to do this for indicies that are true in INDEXER, as this is only remaining valid data
-        if (SIG_Completed_Flag) 
+        if (SIG_Completed_Flag)
             INDEXER[INDEXER] = [x <= SIG_QUALITY_THRESHOLD ? false : true for x in SIG[INDEXER]]
-        else 
-            SIG = [ismissing(x) || isnan(x) ? Float32(FILL_VAL) : Float32(x) for x in calc_sig(cfrad, SIG_QUALITY_VAR)[:]]
+        else
+            SIG = [ismissing(x) || isnan(x) ? Float32(FILL_VAL) : Float32(x) for x in calc_sig(v, SIG_QUALITY_VAR)[:]]
             INDEXER[INDEXER] = [ x <= SIG_QUALITY_THRESHOLD ? false : true for x in SIG[INDEXER]]
-        end 
+        end
 	println("DATAPOINTS AFTER SIGNAL QUALITY THRESHOLD APPLIED: $(sum(INDEXER))") 
     end
 
@@ -796,7 +807,7 @@ function process_single_file(cfrad::NCDataset, tasks::Vector{String};
         if (PGG_Completed_Flag)
             INDEXER[INDEXER] = [x >= PGG_THRESHOLD ? false : true for x in PGG[INDEXER]]
         else
-            PGG = [ismissing(x) || isnan(x) ? Float32(FILL_VAL) : Float32(x) for x in calc_pgg(cfrad)[:]]
+            PGG = [ismissing(x) || isnan(x) ? Float32(FILL_VAL) : Float32(x) for x in calc_pgg(v)[:]]
             INDEXER[INDEXER] = [x >= PGG_THRESHOLD ? false : true for x in PGG[INDEXER]]
         end
 	println("DATAPIONTS AFTER PGG REMOVAL $(sum(INDEXER))") 
@@ -815,8 +826,8 @@ function process_single_file(cfrad::NCDataset, tasks::Vector{String};
         startTime = time() 
         ###try catch block here to see if the scan has interactive QC
         ###Filter the input arrays first 
-        VG = cfrad[QC_variable][:][INDEXER]
-        VV = cfrad[remove_variable][:][INDEXER]
+        VG = v[QC_variable][:][INDEXER]
+        VV = v[remove_variable][:][INDEXER]
 
         Y = reshape([ismissing(x) ? 0 : 1 for x in VG .- VV][:], (:, 1))
         calc_length = time() - startTime
@@ -824,5 +835,11 @@ function process_single_file(cfrad::NCDataset, tasks::Vector{String};
         return(X, Y, INDEXER)
     else
         return(X, false, INDEXER)
-    end 
-end 
+    end
+end
+
+## Back-compat shim: accept an NCDataset (treated as a v1 root view) and
+## delegate to the SweepView method. Keeps the exported process_single_file
+## signature stable.
+process_single_file(cfrad::NCDataset, tasks::Vector{String}; kwargs...) =
+    process_single_file(SweepView(cfrad, nothing, ""), tasks; kwargs...)

--- a/test/unit_tests.jl
+++ b/test/unit_tests.jl
@@ -1044,6 +1044,59 @@ end
         @test length(bank) == 4
     end
 
+    @testset "build_filtered_kernel_bank: silent size-restricted skips" begin
+        types = ["mean", "gaussian", "laplacian", "sobel_range", "sobel_azi"]
+        sizes = [3, 5, 7]
+
+        ## Size-restricted Cartesian-product combos are skipped silently (the
+        ## per-scan log spam this change removes). We assert the *behavior* —
+        ## the correct subset is built — rather than log-absence, to avoid
+        ## pulling the Logging stdlib into the test deps. The skipped set is
+        ## independently characterized in "masked_conv_skipped_combos" below.
+        bank = Ronin.build_filtered_kernel_bank(types, sizes)
+
+        ## Built set: mean@{3,5,7}, gaussian@{5,7}, laplacian@3,
+        ## sobel_range@3, sobel_azi@3  = 3 + 2 + 1 + 1 + 1 = 8
+        @test length(bank) == 8
+        names = [k.name for k in bank]
+        @test "mean_3x3" in names
+        @test "gaussian_5x5" in names && "gaussian_7x7" in names
+        @test "laplacian_3x3" in names
+        @test !("gaussian_3x3" in names)
+        @test !any(n -> startswith(n, "laplacian_5") || startswith(n, "laplacian_7"), names)
+
+        ## Unknown kernel type is still a hard error (genuine misconfig).
+        @test_throws ErrorException Ronin.build_filtered_kernel_bank(["bogus"], [3])
+    end
+
+    @testset "masked_conv_skipped_combos" begin
+        ## Size-restricted kernels at non-canonical sizes are reported.
+        skipped = Ronin.masked_conv_skipped_combos(
+            ["mean", "gaussian", "laplacian", "sobel_range", "sobel_azi"], [3, 5, 7])
+        @test ("gaussian", 3) in skipped
+        @test ("laplacian", 5) in skipped
+        @test ("laplacian", 7) in skipped
+        @test ("sobel_range", 5) in skipped
+        @test ("sobel_azi", 7) in skipped
+        ## Valid combinations are NOT reported as skipped.
+        @test !(("mean", 3) in skipped)
+        @test !(("mean", 7) in skipped)
+        @test !(("gaussian", 5) in skipped)
+        @test !(("laplacian", 3) in skipped)
+        @test !(("sobel_azi", 3) in skipped)
+
+        ## All-valid config → nothing skipped.
+        @test isempty(Ronin.masked_conv_skipped_combos(["mean"], [3, 5, 7]))
+        @test isempty(Ronin.masked_conv_skipped_combos(["gaussian"], [5, 7]))
+
+        ## Reported set is exactly the complement of what the bank builds.
+        types = ["mean", "gaussian", "laplacian", "sobel_range", "sobel_azi"]
+        sizes = [3, 5, 7]
+        n_total = length(types) * length(sizes)
+        n_built = length(Ronin.build_filtered_kernel_bank(types, sizes))
+        @test length(Ronin.masked_conv_skipped_combos(types, sizes)) == n_total - n_built
+    end
+
     @testset "Gaussian kernel properties" begin
         g = Ronin._gaussian_kernel(5)
         @test size(g) == (5, 5)

--- a/test/unit_tests.jl
+++ b/test/unit_tests.jl
@@ -2038,6 +2038,112 @@ end
 
         rm(workdir; recursive=true)
     end
+
+    @testset "_expected_feature_width / _check_feature_width" begin
+        ## selected_features wins when present
+        @test Ronin._expected_feature_width([1, 3, 5], ["a", "b", "c", "d"]) == 3
+        ## else fall back to full feature_names width
+        @test Ronin._expected_feature_width(Int[], ["a", "b", "c", "d"]) == 4
+        ## neither known (legacy save_object) → 0 means "skip the check"
+        @test Ronin._expected_feature_width(Int[], String[]) == 0
+
+        ## Matching width: no error
+        X_ok = zeros(Float32, 5, 4)
+        @test Ronin._check_feature_width(X_ok, Int[], ["a","b","c","d"], "m.jld2", 2) === nothing
+        ## Unknown expected width: skipped, no error
+        @test Ronin._check_feature_width(X_ok, Int[], String[], "m.jld2", 1) === nothing
+        ## Mismatch: actionable error mentioning met_prob, not a BoundsError
+        X_narrow = zeros(Float32, 5, 10)
+        err = try
+            Ronin._check_feature_width(X_narrow, Int[], ["f$(k)" for k in 1:17], "fore_mask.jld2", 2)
+            nothing
+        catch e
+            e
+        end
+        @test err isa ErrorException
+        @test occursin("Feature width mismatch", err.msg)
+        @test occursin("met_prob_pass", err.msg)
+        @test !(err isa BoundsError)
+    end
+
+    @testset "composite_QC 2-pass masked-conv (fore_mask shape) writes met_prob_pass_1" begin
+        ## Reproduces the operational fore_mask failure: Pass 2 consumes
+        ## met_prob_pass_1 as a conv variable AND as the masked-conv met_prob
+        ## field. composite_QC must write met_prob_pass_1 after Pass 1 so Pass 2
+        ## produces a full-width feature matrix (no BoundsError in the RF).
+        workdir = _orch_workdir("orch_foremask_compositeqc")
+        train_cfrad = joinpath(workdir, "train.nc")
+        create_test_cfrad(train_cfrad; range_dim=30, time_dim=40, seed=21)
+
+        model1 = joinpath(workdir, "model_pass1.jld2")
+        model2 = joinpath(workdir, "model_pass2.jld2")
+        feat1  = joinpath(workdir, "feat_pass1.h5")
+        feat2  = joinpath(workdir, "feat_pass2.h5")
+
+        config = Ronin.make_config(;
+            num_models = 2,
+            input_path = train_cfrad,
+            experiment_name = "foremask",
+            model_output_paths = [model1, model2],
+            feature_output_paths = [feat1, feat2],
+            mask_names = ["mask_pass_0", "mask_pass_1"],
+            met_probs = [(0.1f0, 0.9f0), (0.1f0, 0.9f0)],
+            file_preprocessed = [false, false],
+            task_mode = "convolution",
+            conv_variables = ["DBZ", "VEL"],
+            conv_kernel_sizes = [3],
+            HAS_INTERACTIVE_QC = true,
+            QC_var = "VG",
+            remove_var = "VV",
+            REMOVE_LOW_SIG_QUALITY = false,
+            REMOVE_HIGH_PGG = false,
+            SIG_QUALITY_VAR = "NCP",
+            n_trees = 5,
+            max_depth = 4,
+            class_weights = "balanced",
+            compute_feature_importance = false,
+            write_out = true,
+            verbose = false,
+            overwrite_output = true,
+        )
+
+        ## Pass 2 adds met_prob_pass_1 as a predictor and a masked-conv block
+        ## keyed on it (masked_conv_met_prob_field auto-set to met_prob_pass_1).
+        pass_config = Dict(
+            2 => (
+                conv_variables = ["DBZ", "VEL", "met_prob_pass_1"],
+                selected_features = Int[],
+                masked_conv_variables = ["DBZ"],
+                masked_conv_kernel_types = ["mean"],
+                masked_conv_kernel_sizes = [3],
+                masked_conv_threshold = 0.1f0,
+            ),
+        )
+
+        Ronin.train_multi_model(config; pass_config=pass_config)
+        @test isfile(model1)
+        @test isfile(model2)
+
+        ## Run operational QC on a FRESH (unseen) scan via composite_QC 3-arg.
+        infer_cfrad = joinpath(workdir, "infer.nc")
+        create_test_cfrad(infer_cfrad; range_dim=30, time_dim=40, seed=99)
+
+        models = Ronin.DecisionTree.RandomForestClassifier[
+            Ronin.load_model(p, "convolution") for p in config.model_output_paths
+        ]
+        ## Would BoundsError in apply_tree before the fix.
+        Ronin.composite_QC(config, [infer_cfrad], models)
+
+        NCDataset(infer_cfrad) do ds
+            @test haskey(ds, "met_prob_pass_1")
+            @test haskey(ds, "met_prob_pass_2")
+            @test haskey(ds, "mask_pass_1")
+            @test haskey(ds, "VV" * config.QC_SUFFIX)
+            @test haskey(ds, "ZZ" * config.QC_SUFFIX)
+        end
+
+        rm(workdir; recursive=true)
+    end
 end
 
 ###############################################################################

--- a/test/unit_tests.jl
+++ b/test/unit_tests.jl
@@ -1924,6 +1924,120 @@ end
 
         rm(workdir; recursive=true)
     end
+
+    @testset "train_multi_model 2-pass (hand-tuned) — regression for md UndefVarError" begin
+        ## Hand-tuned multi-pass training used to crash in the inter-pass mask
+        ## block at src/Ronin.jl:2683 with `UndefVarError: md not defined`
+        ## because the diagnostic referenced `md.selected_features` outside the
+        ## convolution branch that binds `md`. This test trains a 2-pass
+        ## hand-tuned cascade end-to-end; if it succeeds and writes the mask
+        ## field for Pass 2, the regression is fixed.
+        workdir = _orch_workdir("orch_multipass_ht")
+        cfrad_path = joinpath(workdir, "smoke_mp.nc")
+        create_test_cfrad(cfrad_path; range_dim=30, time_dim=40, seed=13)
+
+        tasks1_path = joinpath(workdir, "tasks_pass1.txt")
+        tasks2_path = joinpath(workdir, "tasks_pass2.txt")
+        create_test_config(tasks1_path, "DBZ, VEL, NCP")
+        create_test_config(tasks2_path, "DBZ, NCP, RNG")
+
+        model1 = joinpath(workdir, "model_pass1.jld2")
+        model2 = joinpath(workdir, "model_pass2.jld2")
+        feat1  = joinpath(workdir, "feat_pass1.h5")
+        feat2  = joinpath(workdir, "feat_pass2.h5")
+
+        config = Ronin.make_config(;
+            num_models = 2,
+            input_path = cfrad_path,
+            experiment_name = "mp_ht",
+            model_output_paths = [model1, model2],
+            feature_output_paths = [feat1, feat2],
+            mask_names = ["mask_pass_0", "mask_pass_1"],
+            met_probs = [(0.1f0, 0.9f0), (0.1f0, 0.9f0)],
+            file_preprocessed = [false, false],
+            task_mode = "",
+            task_paths = Union{String,Vector{String}}[tasks1_path, tasks2_path],
+            task_weights = [
+                [Matrix{Union{Missing,Float32}}(undef, 0, 0)],
+                [Matrix{Union{Missing,Float32}}(undef, 0, 0)],
+            ],
+            HAS_INTERACTIVE_QC = true,
+            QC_var = "VG",
+            remove_var = "VV",
+            REMOVE_LOW_SIG_QUALITY = false,
+            REMOVE_HIGH_PGG = false,
+            SIG_QUALITY_VAR = "NCP",
+            n_trees = 5,
+            max_depth = 4,
+            class_weights = "balanced",
+            write_out = true,
+            verbose = false,
+            overwrite_output = true,
+        )
+
+        Ronin.train_multi_model(config)
+
+        @test isfile(model1)
+        @test isfile(model2)
+        NCDataset(cfrad_path) do ds
+            @test haskey(ds, "met_prob_pass_1")
+            @test haskey(ds, "mask_pass_1")
+        end
+
+        rm(workdir; recursive=true)
+    end
+
+    @testset "train_multi_model 2-pass (convolution) — lock-in" begin
+        ## Companion to the hand-tuned regression test: the convolution branch
+        ## was already binding `md`, but we lacked coverage for any multi-pass
+        ## training path. This locks in the working state.
+        workdir = _orch_workdir("orch_multipass_conv")
+        cfrad_path = joinpath(workdir, "smoke_mp_conv.nc")
+        create_test_cfrad(cfrad_path; range_dim=30, time_dim=40, seed=17)
+
+        model1 = joinpath(workdir, "model_pass1.jld2")
+        model2 = joinpath(workdir, "model_pass2.jld2")
+        feat1  = joinpath(workdir, "feat_pass1.h5")
+        feat2  = joinpath(workdir, "feat_pass2.h5")
+
+        config = Ronin.make_config(;
+            num_models = 2,
+            input_path = cfrad_path,
+            experiment_name = "mp_conv",
+            model_output_paths = [model1, model2],
+            feature_output_paths = [feat1, feat2],
+            mask_names = ["mask_pass_0", "mask_pass_1"],
+            met_probs = [(0.1f0, 0.9f0), (0.1f0, 0.9f0)],
+            file_preprocessed = [false, false],
+            task_mode = "convolution",
+            conv_variables = ["DBZ", "VEL"],
+            conv_kernel_sizes = [3],
+            HAS_INTERACTIVE_QC = true,
+            QC_var = "VG",
+            remove_var = "VV",
+            REMOVE_LOW_SIG_QUALITY = false,
+            REMOVE_HIGH_PGG = false,
+            SIG_QUALITY_VAR = "NCP",
+            n_trees = 5,
+            max_depth = 4,
+            class_weights = "balanced",
+            compute_feature_importance = false,
+            write_out = true,
+            verbose = false,
+            overwrite_output = true,
+        )
+
+        Ronin.train_multi_model(config)
+
+        @test isfile(model1)
+        @test isfile(model2)
+        NCDataset(cfrad_path) do ds
+            @test haskey(ds, "met_prob_pass_1")
+            @test haskey(ds, "mask_pass_1")
+        end
+
+        rm(workdir; recursive=true)
+    end
 end
 
 ###############################################################################

--- a/test/unit_tests.jl
+++ b/test/unit_tests.jl
@@ -1691,6 +1691,242 @@ end
 end
 
 ###############################################################################
+# Convolution-mode orchestration: composite_prediction / composite_QC / QC_scan
+#
+# Guards against regressions where these orchestration functions assumed the
+# hand-tuned (task_paths) feature path and crashed under task_mode="convolution".
+# Each subtest stands up a minimal trained 1-pass convolution model on a
+# synthetic CfRadial, then drives a top-level entry point and asserts the
+# QC field was written back.
+###############################################################################
+
+# Helper: build a writable temporary directory under the test scratchspace
+function _orch_workdir(name::String)
+    dir = joinpath(test_scratchspace, name)
+    isdir(dir) && rm(dir; recursive=true)
+    mkpath(dir)
+    return dir
+end
+
+# Helper: train a 1-pass convolution model on a fresh synthetic CfRadial and
+# return (config, cfrad_path). The model JLD2 is written to disk with metadata,
+# and met_prob_pass_1 / mask_pass_1 fields end up in the CfRadial.
+function _train_smoke_conv_model(workdir::String)
+    cfrad_path = joinpath(workdir, "smoke.nc")
+    create_test_cfrad(cfrad_path; range_dim=30, time_dim=40, seed=7)
+
+    model_path = joinpath(workdir, "model_pass1.jld2")
+    feat_path  = joinpath(workdir, "feat_pass1.h5")
+
+    config = Ronin.make_config(;
+        num_models = 1,
+        input_path = cfrad_path,
+        experiment_name = "smoke_conv",
+        model_output_paths = [model_path],
+        feature_output_paths = [feat_path],
+        mask_names = ["mask_pass_0"],
+        met_probs = [(0.1f0, 0.9f0)],
+        file_preprocessed = [false],
+        task_mode = "convolution",
+        conv_variables = ["DBZ", "VEL"],
+        conv_kernel_sizes = [3],
+        HAS_INTERACTIVE_QC = true,
+        QC_var = "VG",
+        remove_var = "VV",
+        REMOVE_LOW_SIG_QUALITY = false,
+        REMOVE_HIGH_PGG = false,
+        SIG_QUALITY_VAR = "NCP",
+        n_trees = 5,
+        max_depth = 4,
+        class_weights = "balanced",
+        compute_feature_importance = false,
+        write_out = true,
+        verbose = false,
+        overwrite_output = true,
+    )
+
+    Ronin.train_multi_model(config)
+    return config, cfrad_path
+end
+
+# Helper: train a 1-pass hand-tuned model — keeps the 1.1.0 task_paths path
+# under test alongside the convolution path so the convolution branch
+# refactor cannot silently regress the legacy mode.
+function _train_smoke_handtuned_model(workdir::String)
+    cfrad_path = joinpath(workdir, "smoke_ht.nc")
+    create_test_cfrad(cfrad_path; range_dim=30, time_dim=40, seed=11)
+
+    model_path = joinpath(workdir, "model_ht_pass1.jld2")
+    feat_path  = joinpath(workdir, "feat_ht_pass1.h5")
+    tasks_path = joinpath(workdir, "tasks_pass1.txt")
+    create_test_config(tasks_path, "DBZ, VEL, NCP")
+
+    config = Ronin.make_config(;
+        num_models = 1,
+        input_path = cfrad_path,
+        experiment_name = "smoke_ht",
+        model_output_paths = [model_path],
+        feature_output_paths = [feat_path],
+        mask_names = ["mask_pass_0"],
+        met_probs = [(0.1f0, 0.9f0)],
+        file_preprocessed = [false],
+        task_mode = "",
+        task_paths = Union{String,Vector{String}}[tasks_path],
+        task_weights = [[Matrix{Union{Missing,Float32}}(undef, 0, 0)]],
+        HAS_INTERACTIVE_QC = true,
+        QC_var = "VG",
+        remove_var = "VV",
+        REMOVE_LOW_SIG_QUALITY = false,
+        REMOVE_HIGH_PGG = false,
+        SIG_QUALITY_VAR = "NCP",
+        n_trees = 5,
+        max_depth = 4,
+        class_weights = "balanced",
+        write_out = true,
+        verbose = false,
+        overwrite_output = true,
+    )
+
+    Ronin.train_multi_model(config)
+    return config, cfrad_path
+end
+
+@testset "Convolution mode orchestration" begin
+
+    @testset "Assertion shape: QC_scan inner does not require task_paths length in convolution mode" begin
+        ## Regression for the second user-visible crash: in convolution mode,
+        ## task_paths defaults to [""] while mask_names has num_models entries.
+        ## The inner per-file QC_scan must not assert task_paths length.
+        cfg = Ronin.make_config(
+            num_models = 2,
+            input_path = "/nonexistent",
+            experiment_name = "shape",
+            task_mode = "convolution",
+        )
+        @test length(cfg.task_paths) == 1
+        @test length(cfg.mask_names) == 2
+        ## Just exercise the assertion: passing a path that won't open should
+        ## fail *after* the assertion, on the NCDataset open, not at the assert.
+        err = try
+            Ronin.QC_scan(cfg, "/no/such/file.nc", Bool[], Bool[])
+            nothing
+        catch e
+            e
+        end
+        @test err !== nothing
+        @test !(err isa AssertionError)
+    end
+
+    @testset "composite_prediction QC_mode=true (convolution)" begin
+        workdir = _orch_workdir("orch_compred_qc_conv")
+        config, cfrad_path = _train_smoke_conv_model(workdir)
+
+        ## Calling with QC_mode=true must not throw and must write a *_QC field.
+        Ronin.composite_prediction(config; write_predictions_out=false, QC_mode=true)
+
+        NCDataset(cfrad_path) do ds
+            @test haskey(ds, "VV" * config.QC_SUFFIX)
+            @test haskey(ds, "ZZ" * config.QC_SUFFIX)
+        end
+
+        rm(workdir; recursive=true)
+    end
+
+    @testset "QC_scan(config) (convolution)" begin
+        workdir = _orch_workdir("orch_qcscan_conv")
+        config, cfrad_path = _train_smoke_conv_model(workdir)
+
+        ## QC_scan(config) is the workflow-level entry point. Must not hit the
+        ## task_paths-length assertion in convolution mode.
+        Ronin.QC_scan(config)
+
+        NCDataset(cfrad_path) do ds
+            @test haskey(ds, "VV" * config.QC_SUFFIX)
+        end
+
+        rm(workdir; recursive=true)
+    end
+
+    @testset "composite_QC 3-arg (convolution)" begin
+        workdir = _orch_workdir("orch_compositeqc3_conv")
+        config, cfrad_path = _train_smoke_conv_model(workdir)
+
+        models = Ronin.DecisionTree.RandomForestClassifier[
+            Ronin.load_model(p, "convolution") for p in config.model_output_paths
+        ]
+        Ronin.composite_QC(config, [cfrad_path], models)
+
+        NCDataset(cfrad_path) do ds
+            @test haskey(ds, "VV" * config.QC_SUFFIX)
+        end
+
+        rm(workdir; recursive=true)
+    end
+
+    @testset "composite_QC 2-arg (convolution)" begin
+        workdir = _orch_workdir("orch_compositeqc2_conv")
+        config, cfrad_path = _train_smoke_conv_model(workdir)
+
+        Ronin.composite_QC(config, [cfrad_path])
+
+        NCDataset(cfrad_path) do ds
+            @test haskey(ds, "VV" * config.QC_SUFFIX)
+        end
+
+        rm(workdir; recursive=true)
+    end
+
+    @testset "composite_QC 3-arg (hand-tuned task_paths) — back-compat" begin
+        ## Locks in 1.1.0 behavior: the hand-tuned path must remain working
+        ## after the convolution branch refactor.
+        workdir = _orch_workdir("orch_compositeqc3_ht")
+        config, cfrad_path = _train_smoke_handtuned_model(workdir)
+
+        models = Ronin.DecisionTree.RandomForestClassifier[
+            Ronin.load_model(p, "") for p in config.model_output_paths
+        ]
+        Ronin.composite_QC(config, [cfrad_path], models)
+
+        NCDataset(cfrad_path) do ds
+            @test haskey(ds, "VV" * config.QC_SUFFIX)
+        end
+
+        rm(workdir; recursive=true)
+    end
+
+    @testset "QC_scan(config) (hand-tuned) — back-compat" begin
+        workdir = _orch_workdir("orch_qcscan_ht")
+        config, cfrad_path = _train_smoke_handtuned_model(workdir)
+
+        Ronin.QC_scan(config)
+
+        NCDataset(cfrad_path) do ds
+            @test haskey(ds, "VV" * config.QC_SUFFIX)
+        end
+
+        rm(workdir; recursive=true)
+    end
+
+    @testset "construct_next_pass_features (convolution)" begin
+        workdir = _orch_workdir("orch_cnpf_conv")
+        config, cfrad_path = _train_smoke_conv_model(workdir)
+
+        ## Pass index 1 on a 1-pass model: features get written to
+        ## feature_output_paths[1], no mask gets written for a "next" pass.
+        Ronin.construct_next_pass_features(config, 1; write_out=true)
+
+        @test isfile(config.feature_output_paths[1])
+        h5open(config.feature_output_paths[1]) do f
+            @test haskey(f, "X")
+            @test haskey(f, "Y")
+            @test size(f["X"][:,:], 1) > 0
+        end
+
+        rm(workdir; recursive=true)
+    end
+end
+
+###############################################################################
 # Cleanup
 ###############################################################################
 @testset "Cleanup test scratch space" begin

--- a/test/unit_tests.jl
+++ b/test/unit_tests.jl
@@ -1444,6 +1444,37 @@ end
 
         rm(model_path)
     end
+
+    ## Regression: issue #41. compute_importance unconditionally re-saves
+    ## the model with jldsave, so a non-convolution workflow ends up with
+    ## a multi-key file. The loader must accept that regardless of task_mode.
+    @testset "jldsave multi-key file with non-convolution task_mode" begin
+        model_path = joinpath(test_scratchspace, "test_model_issue41.jld2")
+        isfile(model_path) && rm(model_path)
+
+        Random.seed!(42)
+        n = 100
+        X = randn(Float32, n, 4)
+        Y = [x > 0 ? 1 : 0 for x in X[:, 1]]
+        model = Ronin.DecisionTree.build_forest(Y, X, 2, 5, 0.7, 4)
+
+        JLD2.jldsave(model_path;
+            model=model,
+            selected_features=Int[],
+            recommended_features=[1, 3],
+            feature_names=["a", "b", "c", "d"],
+            importances=[0.1, 0.001, 0.05, 0.02])
+
+        md = Ronin.load_model_with_metadata(model_path, "")
+        @test md.model isa Ronin.DecisionTree.Ensemble
+        @test md.recommended_features == [1, 3]
+        @test md.feature_names == ["a", "b", "c", "d"]
+
+        m = Ronin.load_model(model_path, "")
+        @test m isa Ronin.DecisionTree.Ensemble
+
+        rm(model_path)
+    end
 end
 
 @testset "inspect_model_configuration" begin

--- a/test/unit_tests.jl
+++ b/test/unit_tests.jl
@@ -2200,6 +2200,225 @@ end
 end
 
 ###############################################################################
+# CfRadial 2.0 support: synthesized v1/v2 fixtures + equivalence test
+###############################################################################
+
+## Produce one deterministic set of sweep data, then write it into either a
+## CfRadial 1.x flat layout or a CfRadial 2.0 hierarchical (/sweep_NNNN +
+## /georeference) layout. Both files contain *identical* radar field bytes;
+## the only difference is on-disk structure. This lets us assert that
+## composite_QC produces identical outputs on the two layouts.
+function _gen_sweep_data(range_dim::Int, time_dim::Int, seed::Int)
+    rng = MersenneTwister(seed)
+    times  = collect(Float32, 1:time_dim)
+    ranges = collect(Float32, 150:150:150*range_dim)
+    alts   = fill(Float32(3000.0), time_dim)
+    elevs  = Float32.(rand(rng, collect(-20:0.5:20), time_dim))
+    azims  = Float32.(rand(rng, collect(0:1:359),  time_dim))
+    VEL    = Matrix{Union{Missing, Float32}}(Float32.(rand(rng, -30:0.1:30, range_dim, time_dim)))
+    DBZ    = Matrix{Union{Missing, Float32}}(Float32.(rand(rng, -10:0.5:65, range_dim, time_dim)))
+    NCP    = Matrix{Union{Missing, Float32}}(Float32.(rand(rng, collect(range(0.0, 1.0, length=100)), range_dim, time_dim)))
+    VG     = copy(VEL)
+    nmd_mask = rand(rng, Bool, range_dim, time_dim)
+    VG[nmd_mask] .= missing
+    return (; times, ranges, alts, elevs, azims, VEL, DBZ, NCP, VG)
+end
+
+function _write_v1_cfrad(path, data)
+    isfile(path) && rm(path)
+    ds = NCDataset(path, "c")
+    defDim(ds, "range", length(data.ranges))
+    defDim(ds, "time",  length(data.times))
+    defVar(ds, "time",      Float32, ("time",),  attrib=Dict("units"=>"seconds"))[:] = data.times
+    defVar(ds, "range",     Float32, ("range",), attrib=Dict("units"=>"m"))[:] = data.ranges
+    defVar(ds, "altitude",  Float32, ("time",),  attrib=Dict("units"=>"m"))[:] = data.alts
+    defVar(ds, "elevation", Float32, ("time",),  attrib=Dict("units"=>"degrees"))[:] = data.elevs
+    defVar(ds, "azimuth",   Float32, ("time",),  attrib=Dict("units"=>"degrees"))[:] = data.azims
+    defVar(ds, "VV",  data.VEL, ("range","time"), attrib=Dict("units"=>"m/s"))
+    defVar(ds, "VEL", data.VEL, ("range","time"), attrib=Dict("units"=>"m/s"))
+    defVar(ds, "ZZ",  data.DBZ, ("range","time"), attrib=Dict("units"=>"dBZ"))
+    defVar(ds, "DBZ", data.DBZ, ("range","time"), attrib=Dict("units"=>"dBZ"))
+    defVar(ds, "NCP", data.NCP, ("range","time"), attrib=Dict("units"=>"unitless"))
+    defVar(ds, "VG",  data.VG,  ("range","time"), attrib=Dict("units"=>"m/s"))
+    close(ds)
+    return path
+end
+
+function _write_v2_cfrad(path, sweep_data_list)
+    isfile(path) && rm(path)
+    ds = NCDataset(path, "c")
+    ds.attrib["Conventions"] = "Cf/Radial-2.0"
+    n_sweeps = length(sweep_data_list)
+    defDim(ds, "sweep", n_sweeps)
+    defDim(ds, "string_length_32", 32)
+    sg_name_var = defVar(ds, "sweep_group_name", Char, ("string_length_32","sweep"))
+    for (si, _) in enumerate(sweep_data_list)
+        name = "sweep_" * lpad(string(si), 4, '0')
+        for (j, c) in enumerate(name)
+            sg_name_var[j, si] = c
+        end
+        for j in (length(name)+1):32
+            sg_name_var[j, si] = '\0'
+        end
+    end
+    for (si, data) in enumerate(sweep_data_list)
+        sg_name = "sweep_" * lpad(string(si), 4, '0')
+        sg = defGroup(ds, sg_name)
+        defDim(sg, "range", length(data.ranges))
+        defDim(sg, "time",  length(data.times))
+        defVar(sg, "time",      Float32, ("time",),  attrib=Dict("units"=>"seconds"))[:] = data.times
+        defVar(sg, "range",     Float32, ("range",), attrib=Dict("units"=>"m"))[:] = data.ranges
+        defVar(sg, "elevation", Float32, ("time",),  attrib=Dict("units"=>"degrees"))[:] = data.elevs
+        defVar(sg, "azimuth",   Float32, ("time",),  attrib=Dict("units"=>"degrees"))[:] = data.azims
+        defVar(sg, "VV",  data.VEL, ("range","time"), attrib=Dict("units"=>"m/s"))
+        defVar(sg, "VEL", data.VEL, ("range","time"), attrib=Dict("units"=>"m/s"))
+        defVar(sg, "ZZ",  data.DBZ, ("range","time"), attrib=Dict("units"=>"dBZ"))
+        defVar(sg, "DBZ", data.DBZ, ("range","time"), attrib=Dict("units"=>"dBZ"))
+        defVar(sg, "NCP", data.NCP, ("range","time"), attrib=Dict("units"=>"unitless"))
+        defVar(sg, "VG",  data.VG,  ("range","time"), attrib=Dict("units"=>"m/s"))
+        # CfRadial 2.0 stores georeference vars under /sweep_NNNN/georeference
+        gref = defGroup(sg, "georeference")
+        defVar(gref, "altitude", Float32, ("time",), attrib=Dict("units"=>"m"))[:] = data.alts
+    end
+    close(ds)
+    return path
+end
+
+## Build a config + train a tiny model that both layouts can be QC'd with.
+function _v2_train_minimal(workdir, train_path)
+    model_path = joinpath(workdir, "model_pass1.jld2")
+    feat_path  = joinpath(workdir, "feat_pass1.h5")
+    config = make_config(
+        num_models = 1,
+        input_path = train_path,
+        experiment_name = "v2eq",
+        task_mode = "convolution",
+        conv_variables = ["DBZ", "VEL"],
+        conv_kernel_sizes = [3],
+        REMOVE_LOW_SIG_QUALITY = false,
+        REMOVE_HIGH_PGG = false,
+        SIG_QUALITY_VAR = "NCP",
+        QC_var = "VG",
+        remove_var = "VV",
+        VARS_TO_QC = ["DBZ", "VEL"],
+        met_probs = [(0.0f0, 0.5f0)],
+        HAS_INTERACTIVE_QC = true,
+        QC_mask = false,
+        n_trees = 5,
+        max_depth = 4,
+        class_weights = "balanced",
+        verbose = false,
+    )
+    config.model_output_paths   = [model_path]
+    config.feature_output_paths = [feat_path]
+    train_multi_model(config)
+    return config, model_path
+end
+
+@testset "CfRadial 2.0 layout support" begin
+    workdir = joinpath(test_scratchspace, "v2_layout")
+    isdir(workdir) && rm(workdir; recursive=true)
+    mkdir(workdir)
+
+    range_dim = 12
+    time_dim  = 16
+    data = _gen_sweep_data(range_dim, time_dim, 4242)
+
+    ## Build v1 and v2 fixtures with byte-identical sweep data, plus a v1
+    ## training-data file the model is trained on (so both inference targets
+    ## start from the same trained model).
+    v1_train = joinpath(workdir, "v1_train.nc"); _write_v1_cfrad(v1_train, data)
+    v1_infer = joinpath(workdir, "v1_infer.nc"); _write_v1_cfrad(v1_infer, data)
+    v2_infer = joinpath(workdir, "v2_infer.nc"); _write_v2_cfrad(v2_infer, [data])
+
+    @testset "sweep_views factory" begin
+        v1_views = NCDataset(v1_infer) do f; Ronin.sweep_views(f); end
+        v2_views = NCDataset(v2_infer) do f; Ronin.sweep_views(f); end
+        @test length(v1_views) == 1
+        @test length(v2_views) == 1
+        @test v1_views[1].sweep_name == ""
+        @test v2_views[1].sweep_name == "sweep_0001"
+        @test v1_views[1].georef === nothing
+        @test v2_views[1].georef !== nothing
+    end
+
+    @testset "georef routes correctly per layout" begin
+        ## v1 reads altitude at root; v2 reads it from /sweep_NNNN/georeference.
+        NCDataset(v1_infer) do f
+            v = Ronin.sweep_views(f)[1]
+            @test Float32.(Ronin.georef(v, "altitude")[:]) == data.alts
+        end
+        NCDataset(v2_infer) do f
+            v = Ronin.sweep_views(f)[1]
+            @test Float32.(Ronin.georef(v, "altitude")[:]) == data.alts
+        end
+    end
+
+    ## Train one model on the v1 file; both inference files use it.
+    config, model_path = _v2_train_minimal(workdir, v1_train)
+
+    @testset "composite_QC: v1 vs v2 outputs are byte-identical" begin
+        ## Run composite_QC against v1 (writes at root) and v2 (writes into
+        ## /sweep_0001). For the same model and same input bytes, the
+        ## met_prob, mask, and per-variable QC fields should be identical.
+        Ronin.composite_QC(config, [v1_infer])
+        Ronin.composite_QC(config, [v2_infer])
+
+        v1_mp, v1_dbzqc, v1_velqc = NCDataset(v1_infer) do f
+            (f["met_prob_pass_1"][:,:], f["DBZ_QC"][:,:], f["VEL_QC"][:,:])
+        end
+        v2_mp, v2_dbzqc, v2_velqc = NCDataset(v2_infer) do f
+            sg = f.group["sweep_0001"]
+            (sg["met_prob_pass_1"][:,:], sg["DBZ_QC"][:,:], sg["VEL_QC"][:,:])
+        end
+
+        @test isequal(v1_mp,   v2_mp)
+        @test isequal(v1_dbzqc, v2_dbzqc)
+        @test isequal(v1_velqc, v2_velqc)
+
+        ## And — crucially — v2 outputs land in /sweep_0001, NOT at root.
+        NCDataset(v2_infer) do f
+            @test !("DBZ_QC" in keys(f))
+            @test !("VEL_QC" in keys(f))
+            @test !("met_prob_pass_1" in keys(f))
+            sg = f.group["sweep_0001"]
+            @test "DBZ_QC" in keys(sg)
+            @test "VEL_QC" in keys(sg)
+            @test "met_prob_pass_1" in keys(sg)
+        end
+    end
+
+    @testset "composite_QC: multi-sweep v2 writes per-sweep" begin
+        ## Build a 2-sweep v2 file with *different* data per sweep, run
+        ## composite_QC, and assert that each /sweep_NNNN group ends up with
+        ## its own independent met_prob_pass_1 / DBZ_QC / VEL_QC.
+        data_a = _gen_sweep_data(range_dim, time_dim, 1111)
+        data_b = _gen_sweep_data(range_dim, time_dim, 2222)
+        v2_multi = joinpath(workdir, "v2_multi.nc")
+        _write_v2_cfrad(v2_multi, [data_a, data_b])
+
+        Ronin.composite_QC(config, [v2_multi])
+
+        NCDataset(v2_multi) do f
+            sg1 = f.group["sweep_0001"]
+            sg2 = f.group["sweep_0002"]
+            for sg in (sg1, sg2)
+                @test "met_prob_pass_1" in keys(sg)
+                @test "DBZ_QC" in keys(sg)
+                @test "VEL_QC" in keys(sg)
+            end
+            ## Different inputs ⇒ different per-sweep outputs (sanity that
+            ## one sweep's writes did not bleed into the other's group).
+            mp1 = sg1["met_prob_pass_1"][:,:]
+            mp2 = sg2["met_prob_pass_1"][:,:]
+            @test !isequal(mp1, mp2)
+        end
+    end
+
+    rm(workdir; recursive=true)
+end
+
+###############################################################################
 # Cleanup
 ###############################################################################
 @testset "Cleanup test scratch space" begin


### PR DESCRIPTION
## Summary

Three orchestration functions still assumed the hand-tuned `task_paths` feature path and crashed under `task_mode = \"convolution\"`. This PR adds the missing convolution branch to each, mirroring the pattern already present in `composite_prediction` and `train_multi_model`. The 1.1.0 hand-tuned path is preserved unchanged.

### Bugs fixed

- **`composite_QC`** — `SystemError(\"opening file \\\"\\\"\")` via `readlines(\"\")` in `get_task_params`, because `composite_QC` called the hand-tuned `process_single_file(::String)` with `config.task_paths[i]`, which defaults to `[\"\"]` in convolution mode.
- **`QC_scan(config, file, preds, init_idxer)`** — `AssertionError` on `task_paths`/`task_weights` length. This was the assertion `QC_scan(config)` → `composite_prediction(QC_mode=true)` hit when called against a convolution config.
- **`construct_next_pass_features`** — same hand-tuned assumption, reached via `evaluate_model(config; features_calculated=false)` and `characterize_misclassified_gates(...; features_precalculated=false)`.
- **`evaluate_model` results DataFrame (cosmetic)** — `task_paths` column now carries `conv_variables` in convolution mode instead of the empty default `[\"\"]`.

### Convenience addition

Adds a 2-arg `composite_QC(config::ModelConfig, files::Vector{String})` method that loads the random forests internally from `config.model_output_paths`. The 1.1.0 3-arg signature is untouched.

### Tests

New `@testset \"Convolution mode orchestration\"` in `test/unit_tests.jl` — 15 assertions across:
- assertion-shape regression for the `QC_scan` inner assertion (no training needed; catches the crash in isolation)
- end-to-end smoke for `composite_prediction(...; QC_mode=true)`, `QC_scan(config)`, `composite_QC` 3-arg, `composite_QC` 2-arg in convolution mode
- end-to-end smoke for `composite_QC` 3-arg and `QC_scan(config)` in hand-tuned mode (1.1.0 back-compat lock)
- end-to-end smoke for `construct_next_pass_features` in convolution mode

Each smoke test trains a tiny 1-pass model on a synthetic CfRadial via `train_multi_model`, drives the entry point, and asserts the `*<QC_SUFFIX>` field was written back.

## Test plan

- [x] \`Pkg.test()\` passes (761 / 761; +15 new)
- [x] CI passes on this PR
- [x] External review of the convolution-branch dispatch in `composite_QC` and `construct_next_pass_features`