### PR TITLE
Merge pre-loaded metadata + v1.2.0 release audit

### DIFF
--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -1,0 +1,65 @@
+# Known Issues / v1.2.1 Backlog
+
+Items identified during the pre-v1.2.0 code audit that were intentionally
+**deferred** because addressing them requires changing validated numerical
+behavior and/or non-trivial new testing. None of these block v1.2.0; the
+v1.2.0 behavior is the version validated against real-world data.
+
+## Deferred — require re-validation before changing
+
+### 1. `masked_convolve` normalization of zero-sum (differential) kernels
+- **Where:** `src/RoninConvolutions.jl` — `masked_convolve`.
+- **What:** Every kernel, including the zero-sum `laplacian` and `sobel_*`
+  stencils, is normalized by `weighted_sum / sum(abs.(kernel))` over valid
+  neighbors. For smoothing kernels this is a weighted average; for
+  differential kernels it scales the edge response and renormalizes near
+  edges/missing gates by the valid footprint.
+- **Open question:** whether differential kernels should instead return the
+  raw masked weighted sum (no division) so the edge response is independent
+  of missing-neighbor count.
+- **Why deferred:** this is the validated v1.2.0 behavior and feeds every
+  edge/texture feature to the classifier. Changing it shifts feature values
+  and would require retraining + re-validation. Needs a fixture pinning the
+  intended differential-kernel output before any change.
+
+### 2. `remove_validation` split policy
+- **Where:** `src/Io.jl` — `remove_validation`.
+- **What:** Deterministic every-10th-row stride (always starting at row 1);
+  `STEP = 10` hard-coded; `remove_original=true` deletes the input
+  unconditionally with no guard against `training_output`/`validation_output`
+  colliding with `input_dataset`.
+- **Follow-up:** expose `validation_fraction`/`STEP`; offer a seeded random
+  split (`rng`/`seed` kwarg) for reproducibility; guard the `rm` against path
+  collisions. The exact-partition test added in v1.2.0
+  (`test/unit_tests.jl`, "remove_validation split") pins the current behavior.
+
+## Deferred — performance / cleanup (no behavior change)
+
+### 3. `@eval` in the per-task feature loop
+- **Where:** `src/RoninFeatures.jl` — `process_single_file` (spatial/derived
+  task dispatch).
+- **What:** Dynamic dispatch via `@eval` in the per-file/per-task hot loop
+  incurs world-age/compilation overhead and returns `Any` (type-unstable).
+- **Follow-up:** replace with an explicit `if/elseif` (or a `Dict` of
+  concrete functions) over the small fixed task set. Pure refactor; should be
+  output-identical and covered by the existing feature tests.
+
+### 4. Thread-unsafe global `REPLACE_MISSING_WITH_FILL`
+- **Where:** `src/RoninFeatures.jl` (global), set from threaded mask-gen in
+  `src/Ronin.jl`.
+- **What:** Module-global mutated inside `Threads.@threads` regions. Currently
+  benign (all threads write the same constant for a given run) but genuinely
+  unsafe.
+- **Follow-up:** thread the flag through as a function argument.
+
+## Fixed in v1.2.0 (for reference)
+
+These were found in the same audit and fixed because they were unambiguous
+bugs / bit-identical perf wins:
+- `get_task_params` never skipped `#` comment lines (Char-vs-String compare).
+- `composite_prediction` skip-path re-flattened the feature mask every
+  iteration (O(n²) allocation).
+- `masked_convolve` re-summed the loop-invariant `total_abs_weight` per gate.
+- `_detect_cfrad_layout` `:ok` branch computed an unused, throw-prone dim tuple.
+- `mask_features=true` silently ignored caller-supplied weight matrices.
+- `predict_log_proba` used the matrix logarithm instead of elementwise `log.`.

--- a/src/DecisionTree/scikitlearnAPI.jl
+++ b/src/DecisionTree/scikitlearnAPI.jl
@@ -72,7 +72,7 @@ predict_proba(dt::DecisionTreeClassifier, X) =
     apply_tree_proba(dt.root, X, dt.classes)
 
 predict_log_proba(dt::DecisionTreeClassifier, X) =
-    log(predict_proba(dt, X)) # this will yield -Inf when p=0. Hmmm...
+    log.(predict_proba(dt, X)) # elementwise; yields -Inf when p=0. Hmmm...
 
 function show(io::IO, dt::DecisionTreeClassifier)
     println(io, "DecisionTreeClassifier")

--- a/src/Io.jl
+++ b/src/Io.jl
@@ -23,9 +23,16 @@ validation_output::String = "validation.h5"
 Path to output validation features to
 
 ```julia
-remove_original::Bool = true 
+remove_original::Bool = true
 ```
-Whether or not to remove the original file described by the `input_dataset` path. 
+Whether or not to remove the original file described by the `input_dataset` path.
+
+NOTE: the split is a *deterministic* stride — every 10th row (indices 1, 11, 21, …)
+goes to the validation set and the remainder to training. This is not a randomized
+split; if the feature matrix is ordered (e.g. grouped by sweep/time), the validation
+set inherits that structure. `remove_original=true` (the default) deletes the input
+file after writing the outputs, so pass distinct output paths. See docs/KNOWN_ISSUES.md
+for the v1.2.1 follow-up (optional seeded random split + path-collision guard).
 """
 function remove_validation(input_dataset::String; training_output::String="train_no_validation_set.h5", 
                             validation_output::String = "validation.h5", remove_original::Bool=true)

--- a/src/Ronin.jl
+++ b/src/Ronin.jl
@@ -218,7 +218,7 @@ module Ronin
         elseif !has_root_range || !has_root_time
             return (:unsupported, (0, 0))
         else
-            return (:ok, (dimsize(f["range"]).range, dimsize(f["time"]).time))
+            return (:ok, (0, 0))
         end
     end
 
@@ -4721,12 +4721,12 @@ module Ronin
 
                                 if i > 1
                                     mask_name = config.mask_names[i]
-                                    feature_mask = Matrix{Bool}(.! map(ismissing, v[mask_name]))
-                                    indexer = [indexer[j] ? feature_mask[:][j] : false for j in eachindex(indexer)]
+                                    feature_mask = vec(Matrix{Bool}(.! map(ismissing, v[mask_name])))
+                                    indexer = [indexer[j] ? feature_mask[j] : false for j in eachindex(indexer)]
                                 elseif config.QC_mask
                                     mask_name = config.mask_names[i]
-                                    feature_mask = Matrix{Bool}(.! map(ismissing, v[mask_name]))
-                                    indexer = [indexer[j] ? feature_mask[:][j] : false for j in eachindex(indexer)]
+                                    feature_mask = vec(Matrix{Bool}(.! map(ismissing, v[mask_name])))
+                                    indexer = [indexer[j] ? feature_mask[j] : false for j in eachindex(indexer)]
                                 end
 
                                 if config.REMOVE_HIGH_PGG

--- a/src/Ronin.jl
+++ b/src/Ronin.jl
@@ -145,6 +145,15 @@ module Ronin
         end
     end
 
+    ## Internal: load `load_model_with_metadata` for every entry in
+    ## `config.model_output_paths`. Used by the 2-arg/3-arg `composite_QC`
+    ## wrappers and `composite_prediction` so the load loop lives in one place.
+    ## No `::ModelConfig` annotation — `ModelConfig` is defined later in the file.
+    function _load_composite_metadata(config)
+        return [load_model_with_metadata(p, config.task_mode)
+                for p in config.model_output_paths]
+    end
+
     ## Internal: the number of feature columns a trained model expects.
     ## A model trained on a `selected_features` subset expects that many columns;
     ## otherwise it expects the full saved `feature_names` width. Returns 0 when
@@ -4631,28 +4640,19 @@ module Ronin
         values = BitVector(undef, 0)
         total_met_probs = Vector{Float32}(undef, 0)
         init_idxers = Vector{Vector{Float32}}(undef, 0)
-        models = []
-        model_selected_features = Vector{Vector{Int}}()
-
-        model_conv_variables = Vector{Vector{String}}()
-        model_feature_names = Vector{Vector{String}}()
-        model_masked_conv_variables = Vector{Vector{String}}()
-        model_masked_conv_kernel_types = Vector{Vector{String}}()
-        model_masked_conv_kernel_sizes = Vector{Vector{Int}}()
-        model_masked_conv_thresholds = Vector{Float32}()
-        model_masked_conv_met_prob_fields = Vector{String}()
-        for path in config.model_output_paths
-            md = load_model_with_metadata(path, config.task_mode)
-            push!(models, md.model)
-            push!(model_selected_features, md.selected_features)
-            push!(model_feature_names, md.feature_names)
-            push!(model_conv_variables, md.conv_variables)
-            push!(model_masked_conv_variables, md.masked_conv_variables)
-            push!(model_masked_conv_kernel_types, md.masked_conv_kernel_types)
-            push!(model_masked_conv_kernel_sizes, md.masked_conv_kernel_sizes)
-            push!(model_masked_conv_thresholds, md.masked_conv_threshold)
-            push!(model_masked_conv_met_prob_fields, md.masked_conv_met_prob_field)
-        end
+        ## Single JLD2 read per model — `_load_composite_metadata` returns a
+        ## Vector of NamedTuples from `load_model_with_metadata`. We unpack into
+        ## the per-field vectors the existing pass loop expects.
+        _md_vec = _load_composite_metadata(config)
+        models = Any[md.model for md in _md_vec]
+        model_selected_features = Vector{Int}[md.selected_features for md in _md_vec]
+        model_feature_names = Vector{String}[md.feature_names for md in _md_vec]
+        model_conv_variables = Vector{String}[md.conv_variables for md in _md_vec]
+        model_masked_conv_variables = Vector{String}[md.masked_conv_variables for md in _md_vec]
+        model_masked_conv_kernel_types = Vector{String}[md.masked_conv_kernel_types for md in _md_vec]
+        model_masked_conv_kernel_sizes = Vector{Int}[md.masked_conv_kernel_sizes for md in _md_vec]
+        model_masked_conv_thresholds = Float32[md.masked_conv_threshold for md in _md_vec]
+        model_masked_conv_met_prob_fields = String[md.masked_conv_met_prob_field for md in _md_vec]
 
         ## Collect per-pass probabilities for summary histogram
         pass_probs = [Float32[] for _ in 1:config.num_models]
@@ -5655,6 +5655,9 @@ module Ronin
 
     """
         composite_QC(config::ModelConfig, files::Vector{String},
+                     models::Vector{Ronin.DecisionTree.RandomForestClassifier},
+                     metadata::Vector{<:NamedTuple})
+        composite_QC(config::ModelConfig, files::Vector{String},
                      models::Vector{Ronin.DecisionTree.RandomForestClassifier})
         composite_QC(config::ModelConfig, files::Vector{String})
 
@@ -5665,39 +5668,47 @@ module Ronin
 
     Supports both `task_mode = ""` (hand-tuned `task_paths`) and
     `task_mode = "convolution"`. In convolution mode, per-model metadata
-    (`selected_features`, `conv_variables`, `masked_conv_*`) is loaded internally
-    from each `model_output_paths` JLD2 file; the supplied `models` vector is
-    used only for `predict_proba`.
+    (`selected_features`, `conv_variables`, `masked_conv_*`) is read from each
+    `model_output_paths` JLD2 file; the supplied `models` vector is used only
+    for `predict_proba`.
 
-    The 2-arg form omits `models` and loads the random forests internally as
-    well — convenient for operational pipelines where the snippet is just
-    `composite_QC(load_config(path), files)`.
+    The 4-arg form accepts pre-loaded `metadata` — a vector of NamedTuples as
+    returned by `load_model_with_metadata` — and is intended for chunked
+    pipelines (e.g. Sparrow.jl) that cache model and metadata per-worker so the
+    JLD2 reads are paid once rather than per call. The 3-arg form loads the
+    metadata internally and forwards; the 2-arg form loads both models and
+    metadata internally — convenient for operational pipelines where the snippet
+    is just `composite_QC(load_config(path), files)`.
+
+    Throws `ArgumentError` if `models` or `metadata` length does not match
+    `length(config.model_output_paths)`.
     """
     function composite_QC(config::ModelConfig,
-                                        files::Vector{String}, models::Vector{Ronin.DecisionTree.RandomForestClassifier})
+                                        files::Vector{String},
+                                        models::Vector{Ronin.DecisionTree.RandomForestClassifier},
+                                        metadata::Vector{<:NamedTuple})
 
-        ## Load per-model metadata once (selected_features, conv_variables, masked_conv_*).
-        ## Same pattern as composite_prediction at :4209-4219. In hand-tuned mode the
-        ## returned vectors are empty defaults and aren't used.
-        model_selected_features = Vector{Vector{Int}}()
-        model_feature_names = Vector{Vector{String}}()
-        model_conv_variables = Vector{Vector{String}}()
-        model_masked_conv_variables = Vector{Vector{String}}()
-        model_masked_conv_kernel_types = Vector{Vector{String}}()
-        model_masked_conv_kernel_sizes = Vector{Vector{Int}}()
-        model_masked_conv_thresholds = Vector{Float32}()
-        model_masked_conv_met_prob_fields = Vector{String}()
-        for path in config.model_output_paths
-            md = load_model_with_metadata(path, config.task_mode)
-            push!(model_selected_features, md.selected_features)
-            push!(model_feature_names, md.feature_names)
-            push!(model_conv_variables, md.conv_variables)
-            push!(model_masked_conv_variables, md.masked_conv_variables)
-            push!(model_masked_conv_kernel_types, md.masked_conv_kernel_types)
-            push!(model_masked_conv_kernel_sizes, md.masked_conv_kernel_sizes)
-            push!(model_masked_conv_thresholds, md.masked_conv_threshold)
-            push!(model_masked_conv_met_prob_fields, md.masked_conv_met_prob_field)
-        end
+        n_models = length(config.model_output_paths)
+        length(models) == n_models ||
+            throw(ArgumentError("composite_QC: models length ($(length(models))) " *
+                                "must match config.model_output_paths length ($(n_models))"))
+        length(metadata) == n_models ||
+            throw(ArgumentError("composite_QC: metadata length ($(length(metadata))) " *
+                                "must match config.model_output_paths length ($(n_models))"))
+
+        ## Unpack the pre-loaded NamedTuples into the per-field vectors the pass
+        ## loop below consumes. Equivalent to the old in-function JLD2 harvest,
+        ## but reads from caller-provided metadata so chunked pipelines can amortize
+        ## load_model_with_metadata across many composite_QC calls. In hand-tuned
+        ## mode these fields are empty defaults and aren't used.
+        model_selected_features = Vector{Int}[md.selected_features for md in metadata]
+        model_feature_names = Vector{String}[md.feature_names for md in metadata]
+        model_conv_variables = Vector{String}[md.conv_variables for md in metadata]
+        model_masked_conv_variables = Vector{String}[md.masked_conv_variables for md in metadata]
+        model_masked_conv_kernel_types = Vector{String}[md.masked_conv_kernel_types for md in metadata]
+        model_masked_conv_kernel_sizes = Vector{Int}[md.masked_conv_kernel_sizes for md in metadata]
+        model_masked_conv_thresholds = Float32[md.masked_conv_threshold for md in metadata]
+        model_masked_conv_met_prob_fields = String[md.masked_conv_met_prob_field for md in metadata]
 
         ## Build the kernel bank once for the whole run (convolution mode only;
         ## cheap to construct unconditionally).
@@ -5905,20 +5916,35 @@ module Ronin
     end
 
     """
+        composite_QC(config::ModelConfig, files::Vector{String},
+                     models::Vector{Ronin.DecisionTree.RandomForestClassifier})
+
+    Convenience 3-arg method that loads per-model metadata from
+    `config.model_output_paths` internally and forwards to the 4-arg form.
+    Preserves the v1.1 calling shape; equivalent to:
+
+        metadata = [load_model_with_metadata(p, config.task_mode) for p in config.model_output_paths]
+        composite_QC(config, files, models, metadata)
+    """
+    function composite_QC(config::ModelConfig,
+                          files::Vector{String},
+                          models::Vector{Ronin.DecisionTree.RandomForestClassifier})
+        metadata = _load_composite_metadata(config)
+        composite_QC(config, files, models, metadata)
+    end
+
+    """
         composite_QC(config::ModelConfig, files::Vector{String})
 
-    Convenience 2-arg method that loads the random forests from
-    `config.model_output_paths` internally and forwards to the 3-arg form.
-    Equivalent to:
-
-        models = [load_model(p, config.task_mode) for p in config.model_output_paths]
-        composite_QC(config, files, models)
+    Convenience 2-arg method that loads both the random forests and their
+    metadata from `config.model_output_paths` internally and forwards to the
+    4-arg form. Each JLD2 file is read once (not twice as the previous
+    `load_model` + `load_model_with_metadata` sequence did).
     """
     function composite_QC(config::ModelConfig, files::Vector{String})
-        models = Ronin.DecisionTree.RandomForestClassifier[
-            load_model(p, config.task_mode) for p in config.model_output_paths
-        ]
-        composite_QC(config, files, models)
+        metadata = _load_composite_metadata(config)
+        models = Ronin.DecisionTree.RandomForestClassifier[md.model for md in metadata]
+        composite_QC(config, files, models, metadata)
     end
 
 

--- a/src/RoninConvolutions.jl
+++ b/src/RoninConvolutions.jl
@@ -171,6 +171,17 @@ Returns `(result, valid_fraction)` where:
 - `valid_fraction[i,j]` = fraction of kernel footprint that had valid data (ISO equivalent)
 
 Missing/invalid gates contribute nothing. Edges are zero-padded (treated as invalid).
+
+NOTE: the `weighted_sum / weight_sum` normalization (where `weight_sum` is the sum
+of *absolute* kernel weights over valid neighbors) is applied uniformly to every
+kernel, including the zero-sum differential kernels (`laplacian`, `sobel_*`). This
+is intentional and is the behavior validated against real-world data for v1.2.0:
+for interior gates with a full neighborhood it scales the differential response by
+`sum(abs.(kernel))`, and near edges / missing gates it renormalizes by the valid
+footprint. Changing this normalization would alter every edge/texture feature fed
+to the classifier, so it must not be "fixed" without re-validation. See the v1.2.1
+backlog (docs/KNOWN_ISSUES.md) for the open question of separate smoothing vs. differential
+normalization.
 """
 function masked_convolve(data::Matrix{Float32}, kernel::Matrix{Float32}, valid::AbstractMatrix{Bool};
                          neighbor_mask::AbstractMatrix{Bool}=valid)
@@ -183,6 +194,10 @@ function masked_convolve(data::Matrix{Float32}, kernel::Matrix{Float32}, valid::
     valid_frac = Matrix{Float32}(undef, nrows, ncols)
 
     abs_kernel = abs.(kernel)
+    # `total_abs_weight` is the sum over the full kernel footprint and is
+    # independent of gate position (the abs weight is added for every kernel
+    # tap regardless of bounds/mask), so hoist it out of the hot loop.
+    total_abs_weight = sum(abs_kernel)
 
     @inbounds for j in 1:ncols, i in 1:nrows
         if !valid[i, j]
@@ -193,7 +208,6 @@ function masked_convolve(data::Matrix{Float32}, kernel::Matrix{Float32}, valid::
 
         weighted_sum = 0.0f0
         weight_sum = 0.0f0
-        total_abs_weight = 0.0f0
 
         for dj in -hc:hc, di in -hr:hr
             ni = i + di
@@ -201,13 +215,10 @@ function masked_convolve(data::Matrix{Float32}, kernel::Matrix{Float32}, valid::
             ki = di + hr + 1
             kj = dj + hc + 1
             kw = kernel[ki, kj]
-            akw = abs_kernel[ki, kj]
-
-            total_abs_weight += akw
 
             if ni >= 1 && ni <= nrows && nj >= 1 && nj <= ncols && neighbor_mask[ni, nj]
                 weighted_sum += kw * data[ni, nj]
-                weight_sum += akw
+                weight_sum += abs_kernel[ki, kj]
             end
         end
 

--- a/src/RoninFeatures.jl
+++ b/src/RoninFeatures.jl
@@ -389,16 +389,16 @@ function get_task_params(params_file, variablelist; delimiter=",")
 
     full_tasks = ""
     for itm in tasks
-        if (itm != "") && (itm[1] != "#")
+        if (itm != "") && (itm[1] != '#')
             if full_tasks == ""
                 full_tasks = strip(itm, ',')
-            else 
+            else
                 full_tasks = full_tasks * "," * strip(itm, ',')
-            end 
-        end 
-    end 
+            end
+        end
+    end
 
-    
+
     delimited = split(full_tasks, delimiter)
     for token in delimited
         ###Remove whitespace and see if the token is of the form ABC(DEF)
@@ -445,13 +445,13 @@ function get_task_params(params_file; delimiter = ',')
 
     full_tasks = ""
     for itm in tasks
-        if (itm != "") && (itm[1] != "#")
+        if (itm != "") && (itm[1] != '#')
             if full_tasks == ""
                 full_tasks = strip(itm, ',')
-            else 
+            else
                 full_tasks = full_tasks * "," * strip(itm, ',')
-            end 
-        end 
+            end
+        end
     end 
 
 
@@ -731,7 +731,10 @@ function process_single_file(v::SweepView, tasks::Vector{String};
                 ##will be ignored.
                 currdat[.! feature_mask] .= missing
 
-                raw = @eval $func($currdat)[:]
+                ##Honor custom weights/window here too. When add_weight_matrix is false these
+                ##default to the canonical *_weights / size(*_weights), which equals the function
+                ##defaults, so this is bit-identical to the bare call for the default path.
+                raw = @eval $func($currdat; weights=$weight_matrix, window=$window_size)[:]
 
             else
                 #raw = @eval slide_window(currdat, weight_matrix, $func)[:]

--- a/test/unit_tests.jl
+++ b/test/unit_tests.jl
@@ -1978,6 +1978,87 @@ end
         rm(workdir; recursive=true)
     end
 
+    @testset "composite_QC 4-arg ≡ 3-arg (convolution)" begin
+        ## Equivalence guard for the v1.2.0 perf-branch addition: the new 4-arg
+        ## form (caller-provided pre-loaded metadata) must produce byte-identical
+        ## CfRadial outputs to the 3-arg form (metadata loaded internally) on
+        ## the same input and same models.
+        workdir = _orch_workdir("orch_compositeqc4_equiv_conv")
+        config, cfrad_a = _train_smoke_conv_model(workdir)
+        cfrad_b = joinpath(workdir, "smoke_b.nc")
+        cp(cfrad_a, cfrad_b)
+
+        models = Ronin.DecisionTree.RandomForestClassifier[
+            Ronin.load_model(p, "convolution") for p in config.model_output_paths
+        ]
+        metadata = [Ronin.load_model_with_metadata(p, "convolution")
+                    for p in config.model_output_paths]
+
+        Ronin.composite_QC(config, [cfrad_a], models)
+        Ronin.composite_QC(config, [cfrad_b], models, metadata)
+
+        NCDataset(cfrad_a) do da
+            NCDataset(cfrad_b) do db
+                for field in ("VV_QC", "ZZ_QC", "met_prob_pass_1")
+                    @test haskey(da, field)
+                    @test haskey(db, field)
+                    @test isequal(da[field][:, :], db[field][:, :])
+                end
+            end
+        end
+
+        rm(workdir; recursive=true)
+    end
+
+    @testset "composite_QC 4-arg ≡ 3-arg (hand-tuned) — back-compat" begin
+        workdir = _orch_workdir("orch_compositeqc4_equiv_ht")
+        config, cfrad_a = _train_smoke_handtuned_model(workdir)
+        cfrad_b = joinpath(workdir, "smoke_ht_b.nc")
+        cp(cfrad_a, cfrad_b)
+
+        models = Ronin.DecisionTree.RandomForestClassifier[
+            Ronin.load_model(p, "") for p in config.model_output_paths
+        ]
+        metadata = [Ronin.load_model_with_metadata(p, "")
+                    for p in config.model_output_paths]
+
+        Ronin.composite_QC(config, [cfrad_a], models)
+        Ronin.composite_QC(config, [cfrad_b], models, metadata)
+
+        NCDataset(cfrad_a) do da
+            NCDataset(cfrad_b) do db
+                for field in ("VV_QC", "ZZ_QC", "met_prob_pass_1")
+                    @test haskey(da, field)
+                    @test haskey(db, field)
+                    @test isequal(da[field][:, :], db[field][:, :])
+                end
+            end
+        end
+
+        rm(workdir; recursive=true)
+    end
+
+    @testset "composite_QC 4-arg — ArgumentError on length mismatch" begin
+        workdir = _orch_workdir("orch_compositeqc4_argerr")
+        config, cfrad_path = _train_smoke_conv_model(workdir)
+
+        models = Ronin.DecisionTree.RandomForestClassifier[
+            Ronin.load_model(p, "convolution") for p in config.model_output_paths
+        ]
+        good_metadata = [Ronin.load_model_with_metadata(p, "convolution")
+                         for p in config.model_output_paths]
+
+        ## metadata too long
+        bad_metadata = vcat(good_metadata, good_metadata)
+        @test_throws ArgumentError Ronin.composite_QC(config, [cfrad_path], models, bad_metadata)
+
+        ## models too short
+        short_models = empty(models)
+        @test_throws ArgumentError Ronin.composite_QC(config, [cfrad_path], short_models, good_metadata)
+
+        rm(workdir; recursive=true)
+    end
+
     @testset "QC_scan(config) (hand-tuned) — back-compat" begin
         workdir = _orch_workdir("orch_qcscan_ht")
         config, cfrad_path = _train_smoke_handtuned_model(workdir)

--- a/test/unit_tests.jl
+++ b/test/unit_tests.jl
@@ -379,6 +379,34 @@ end
         rm(config_path2)
     end
 
+    @testset "get_task_params skips comment lines" begin
+        # Lines beginning with '#' must be ignored. Regression guard for the
+        # Char-vs-String comparison bug (`itm[1] != "#"` was always true), which
+        # let a comment line's comma-separated tokens leak into the task list.
+        varlist = ["NCP", "DBZ", "VV"]
+
+        # With variablelist: "AHT" sits after a comma on a commented line and
+        # would be picked up if the comment were not skipped.
+        config_path = joinpath(test_scratchspace, "test_tasks_comment.txt")
+        create_test_config(config_path, "NCP, DBZ\n# STD(VV), AHT")
+        tasks = Ronin.get_task_params(config_path, varlist)
+        @test length(tasks) == 2
+        @test "NCP" in tasks
+        @test "DBZ" in tasks
+        @test !any(t -> occursin("AHT", t), tasks)
+        @test !any(t -> occursin("#", t), tasks)
+        rm(config_path)
+
+        # Without variablelist: "ELV" trails a comma on a commented line.
+        config_path2 = joinpath(test_scratchspace, "test_tasks_comment2.txt")
+        create_test_config(config_path2, "AHT\n#PGG, ELV")
+        tasks2 = Ronin.get_task_params(config_path2)
+        @test "AHT" in tasks2
+        @test !("ELV" in tasks2)
+        @test length(tasks2) == 1
+        rm(config_path2)
+    end
+
     @testset "parse_directory" begin
         test_dir = joinpath(test_scratchspace, "test_parse_dir")
         mkpath(test_dir)
@@ -867,6 +895,9 @@ end
         n = 100
         n_features = 3
         X = randn(Float32, n, n_features)
+        # Tag each row with its 1-based index in column 1 so we can verify the
+        # exact partition (not just the counts) survives the split.
+        X[:, 1] .= Float32.(1:n)
         Y = reshape(rand([0, 1], n), :, 1)
 
         input_path = joinpath(test_scratchspace, "rv_input.h5")
@@ -892,10 +923,26 @@ end
         # Check sizes: every 10th row goes to validation
         h5open(train_path) do ft
             h5open(val_path) do fv
-                n_train = size(ft["X"][:,:])[1]
-                n_val = size(fv["X"][:,:])[1]
+                Xt = ft["X"][:,:]
+                Xv = fv["X"][:,:]
+                n_train = size(Xt)[1]
+                n_val = size(Xv)[1]
                 @test n_train + n_val == n
                 @test n_val == length(1:10:n)  # every 10th row
+
+                # Exact partition: validation rows are precisely 1,11,21,...,
+                # training is the complement, the two are disjoint, and together
+                # they reconstruct the original. Guards against a train/val swap
+                # or stride drift that count-only checks would miss.
+                val_ids = Int.(round.(Xv[:, 1]))
+                train_ids = Int.(round.(Xt[:, 1]))
+                @test sort(val_ids) == collect(1:10:n)
+                @test isempty(intersect(val_ids, train_ids))
+                @test sort(vcat(val_ids, train_ids)) == collect(1:n)
+
+                # Attributes round-trip to both outputs.
+                @test read(attributes(ft)["Parameters"]) == ["F1", "F2", "F3"]
+                @test read(attributes(fv)["Parameters"]) == ["F1", "F2", "F3"]
             end
         end
 
@@ -2305,6 +2352,105 @@ end
             @test haskey(ds, "mask_pass_1")
             @test haskey(ds, "VV" * config.QC_SUFFIX)
             @test haskey(ds, "ZZ" * config.QC_SUFFIX)
+        end
+
+        rm(workdir; recursive=true)
+    end
+
+    @testset "skip_existing_met_probs equivalence (run_evaluation)" begin
+        ## Test A: the skip_existing_met_probs fast path reconstructs the QC
+        ## indexer independently of process_single_file_conv and reads the saved
+        ## met_prob_pass_<i> field instead of recomputing features+predict. Under
+        ## a matched config it MUST yield identical predictions/metrics to the
+        ## full computation. A divergence here (e.g. an indexer mismatch turning a
+        ## valid gate into the -1.0 sentinel) would silently corrupt evaluation
+        ## metrics, so pin the equivalence.
+        workdir = _orch_workdir("orch_skip_equiv_conv")
+        config, cfrad_path = _train_smoke_conv_model(workdir)
+
+        ## Populate met_prob_pass_1 in the CfRadial so the skip path has a field
+        ## to read; composite_QC writes it from the same model + same features.
+        Ronin.composite_QC(config, [cfrad_path])
+
+        probs = [(0.1f0, 0.9f0)]
+        r_full = Ronin.run_evaluation(config, "full", cfrad_path, probs;
+                                      skip_existing_met_probs=false, verbose=false)
+        r_skip = Ronin.run_evaluation(config, "skip", cfrad_path, probs;
+                                      skip_existing_met_probs=true, verbose=false)
+
+        @test r_full.predictions == r_skip.predictions
+        @test r_full.targets == r_skip.targets
+        @test r_full.tp == r_skip.tp
+        @test r_full.fp == r_skip.fp
+        @test r_full.tn == r_skip.tn
+        @test r_full.fn == r_skip.fn
+        @test r_full.n  == r_skip.n
+        @test r_full.f1 == r_skip.f1
+
+        ## Sanity: metrics are well-formed probabilities / counts.
+        @test 0.0 <= r_full.precision <= 1.0
+        @test 0.0 <= r_full.recall <= 1.0
+        @test 0.0 <= r_full.f1 <= 1.0
+        @test r_full.tp + r_full.fp + r_full.tn + r_full.fn == r_full.n
+
+        rm(workdir; recursive=true)
+    end
+
+    @testset "regenerate_masks applies thresholds exactly (met_prob classification)" begin
+        ## Test B: numerically pin the met_prob threshold -> mask decision.
+        ## regenerate_masks reads a saved met_prob_pass_<pass> field and marks a
+        ## gate (1.0f0) iff threshold_low <= p <= threshold_high (inclusive both
+        ## ends), leaving everything else missing. This is the one place the
+        ## threshold arithmetic is exercised on fully controllable inputs, so we
+        ## assert the exact mask on a hand-built probability field that straddles
+        ## both boundaries and includes a missing gate.
+        workdir = _orch_workdir("orch_regen_masks")
+        cfrad_path = joinpath(workdir, "regen.nc")
+        create_test_cfrad(cfrad_path; range_dim=2, time_dim=4, seed=3)
+
+        ## Probabilities chosen to exercise: below-low, exactly-low (included),
+        ## middle, exactly-high (included), above-high, and a missing gate.
+        ## Layout is (range=2, time=4).
+        probs = Union{Missing,Float32}[
+            0.05f0  0.50f0  0.95f0  missing ;
+            0.10f0  0.90f0  0.00f0  1.00f0
+        ]
+        NCDataset(cfrad_path, "a") do f
+            defVar(f, "met_prob_pass_1", probs, ("range", "time"))
+        end
+
+        config = Ronin.make_config(;
+            num_models = 2,
+            input_path = cfrad_path,
+            experiment_name = "regen",
+            mask_names = ["mask_pass_0", "mask_pass_1"],
+            met_probs = [(0.1f0, 0.9f0), (0.1f0, 0.9f0)],
+            task_mode = "convolution",
+            conv_variables = ["DBZ"],
+            conv_kernel_sizes = [3],
+            verbose = false,
+        )
+
+        ## Regenerate the pass-2 mask (writes config.mask_names[2] = "mask_pass_1")
+        ## from met_prob_pass_1 using the inclusive band [0.1, 0.9].
+        Ronin.regenerate_masks(config, 1, (0.1f0, 0.9f0))
+
+        ## Expected: 1.0 where 0.1 <= p <= 0.9, missing otherwise (incl. the
+        ## missing input gate). Boundary values 0.1 and 0.9 are INCLUDED.
+        expected_masked = Bool[
+            false  true   false  false ;   # 0.05 no, 0.50 yes, 0.95 no, missing no
+            true   true   false  false     # 0.10 yes, 0.90 yes, 0.00 no, 1.00 no
+        ]
+
+        NCDataset(cfrad_path) do f
+            mask = f["mask_pass_1"][:, :]
+            for idx in eachindex(mask)
+                if expected_masked[idx]
+                    @test mask[idx] == 1.0f0
+                else
+                    @test ismissing(mask[idx])
+                end
+            end
         end
 
         rm(workdir; recursive=true)


### PR DESCRIPTION
Final preparation for the v1.2.0 registry release.

This branch adds the pre-loaded-metadata entry point and completes a full
pre-release code audit focused on preserving the scientific accuracy already
validated on real-world data.

Feature:
- 4-arg composite_QC(config, files, models, metadata) accepting caller-provided
  metadata, so chunked pipelines can amortize JLD2 reads across calls. The 2-arg
  and 3-arg forms are unchanged.

Audit bug fixes:
- get_task_params now skips '#' comment lines (the Char-vs-String compare was
  always true, leaking commented tokens into the task list).
- process_single_file honors custom weights/window in the mask_features branch
  (was silently dropping caller-supplied weight matrices; bit-identical for the
  default path).
- predict_log_proba uses elementwise log. instead of the matrix logarithm.

Audit performance wins (bit-identical output):
- composite_prediction skip path hoists vec(feature_mask) out of the per-gate
  comprehension (was O(n^2) re-flattening).
- masked_convolve hoists the loop-invariant total_abs_weight = sum(abs_kernel).
- _detect_cfrad_layout :ok branch drops an unused, throw-prone dim tuple.

Tests (886 pass / 0 fail):
- skip_existing_met_probs equivalence (full vs fast path produce identical
  predictions and metrics).
- regenerate_masks exact threshold->mask classification on hand-built probs.
- get_task_params comment-line skipping; remove_validation exact partition.

Docs:
- Documented the intentional masked_convolve normalization and remove_validation
  deterministic-stride behavior; added docs/KNOWN_ISSUES.md as the v1.2.1 backlog.
